### PR TITLE
Deployment doc typo

### DIFF
--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -324,7 +324,7 @@ ExecStop=-/usr/bin/docker stop -t 10 %p
 
 The APK storage plugin loads raw blobs from the main storage unit and allows additional actions to be performed on APK files, such as retrieving the `AndroidManifest.xml`.
 
-This is a template unit, meaning that you'll need to start it with an instance identifier. In this example configuration the identifier is used to specify the exposed port number (i.e. `stf-storate-plugin-apk@3300.service` runs on port 3300). You can have multiple instances running on the same host by using different ports.
+This is a template unit, meaning that you'll need to start it with an instance identifier. In this example configuration the identifier is used to specify the exposed port number (i.e. `stf-storage-plugin-apk@3300.service` runs on port 3300). You can have multiple instances running on the same host by using different ports.
 
 ```ini
 [Unit]

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -473,7 +473,7 @@ ExecStop=-/usr/bin/docker stop -t 10 %p
 
 The websocket unit provides the communication layer between client-side JavaScript and the server-side ZeroMQ+Protobuf combination. Almost every action in STF goes through the websocket unit.
 
-This is a template unit, meaning that you'll need to start it with an instance identifier. In this example configuration the identifier is used to specify the exposed port number (i.e. `stf-storage-plugin-image@3600.service` runs on port 3600). You can have multiple instances running on the same host by using different ports.
+This is a template unit, meaning that you'll need to start it with an instance identifier. In this example configuration the identifier is used to specify the exposed port number (i.e. `stf-websocket@3600.service` runs on port 3600). You can have multiple instances running on the same host by using different ports.
 
 ```ini
 [Unit]


### PR DESCRIPTION
A couple of typos in the excellent deployment docs. It may be worth bumping the embedded version number to 1.0.3 or a generic tag such as latest or stable? Using the mock auth provider I'm not able to log in, get 302'd to /undefined. Thanks!