### PR TITLE
Fix proxy_path for stf-auth in sample nginx.conf

### DIFF
--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -688,8 +688,8 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
     }
 
-    location /auth/mock/ {
-      proxy_pass http://stf_auth/auth/mock/;
+    location /auth/ {
+      proxy_pass http://stf_auth/auth/;
     }
 
     location /s/image/ {


### PR DESCRIPTION
With current sample nginx.conf, endpoint such as [/auth/api/v1/mock](https://github.com/openstf/stf/blob/master/lib/units/auth/mock.js#L60) or [/auth/api/v1/ldap](https://github.com/openstf/stf/blob/master/lib/units/auth/ldap.js#L61) will be proxied to stf-app instead of stf-auth server which will cause status 302 with /undefined endpoint.

This is a small fix for above problem.