### PR TITLE
Fixed Error :  spawn gm ENOENT

### DIFF
--- a/lib/units/storage/plugins/image/task/transform.js
+++ b/lib/units/storage/plugins/image/task/transform.js
@@ -1,4 +1,4 @@
-var gm = require('gm')
+var gm = require('gm').subClass({ imageMagick: true });
 var Promise = require('bluebird')
 
 module.exports = function(stream, options) {


### PR DESCRIPTION
Fixed a bug related with gm module. 
This error is raised when storage-plugin-image server is seperated.
The error is shown the following.
```javascript
Error: spawn gm ENOENT
    at exports._errnoException (util.js:746:11)
    at Process.ChildProcess._handle.onexit (child_process.js:1053:32)
    at child_process.js:1144:20
    at process._tickCallback (node.js:355:11)
error: Forever detected script exited with code: 1
error: Script restart attempt #16
INF/storage:plugins:image 16186 [*] Listening on port 7103
events.js:85
      throw er; // Unhandled 'error' event
```