### PR TITLE
Fix portrait/landscape buttons clickable area

### DIFF
--- a/res/app/control-panes/device-control/device-control.jade
+++ b/res/app/control-panes/device-control/device-control.jade
@@ -15,7 +15,7 @@
             i(ng-show='showScreen', tooltip-html-unsafe='{{"Hide Screen"|translate}}', tooltip-placement='bottom').fa.fa-eye
             i(ng-show='!showScreen', tooltip-html-unsafe='{{"Show Screen"|translate}}', tooltip-placement='bottom').fa.fa-eye-slash
 
-        .device-name-container(dropdown)
+        .device-name-container.dropdown.pull-left
           a.stf-vnc-device-name.pointer.unselectable(dropdown-toggle)
             p
               .device-small-image


### PR DESCRIPTION
Without these changes, the dropdown occluded the buttons area:

![screen shot 2015-09-28 at 10 26 02 am](https://cloud.githubusercontent.com/assets/1577721/10136970/a376d190-65cd-11e5-832c-a0b849fec60c.png)

Adding a pull-left solves it:

![screen shot 2015-09-28 at 10 43 53 am](https://cloud.githubusercontent.com/assets/1577721/10137029/df881cf2-65cd-11e5-9e57-dcecc90f8bf5.png)


