### PR TITLE
Fix portrait/landscape buttons clickable area

### DIFF
--- a/res/app/control-panes/device-control/device-control.css
+++ b/res/app/control-panes/device-control/device-control.css
@@ -183,7 +183,6 @@ device-screen input {
 
 .stf-device-control .kick-device {
   color: #9c9c9c;
-  margin-left: 25px;
 }
 
 .stf-device-control .kick-device:hover {
@@ -267,6 +266,10 @@ device-screen input {
 
 .stf-vnc-right-buttons .button-spacer {
   width: 12px;
+}
+
+.dropdown-menu > li > a.stf-device-control {
+  margin-left: 7px;
 }
 
 .no-transition {

--- a/res/app/control-panes/device-control/device-control.jade
+++ b/res/app/control-panes/device-control/device-control.jade
@@ -15,7 +15,7 @@
             i(ng-show='showScreen', tooltip-html-unsafe='{{"Hide Screen"|translate}}', tooltip-placement='bottom').fa.fa-eye
             i(ng-show='!showScreen', tooltip-html-unsafe='{{"Show Screen"|translate}}', tooltip-placement='bottom').fa.fa-eye-slash
 
-        .device-name-container(dropdown)
+        .device-name-container.pull-left(dropdown)
           a.stf-vnc-device-name.pointer.unselectable(dropdown-toggle)
             p
               .device-small-image
@@ -25,7 +25,7 @@
 
           ul.dropdown-menu(role='menu', data-toggle='dropdown', ng-show='groupDevices.length > 0').pointer.unselectable
             li(ng-repeat='groupDevice in groupDevices')
-              a(ng-click='controlDevice(groupDevice); $event.stopPropagation()')
+              a.stf-device-control(ng-click='controlDevice(groupDevice); $event.stopPropagation()')
                 .pull-left
                   .device-small-image
                     img(ng-src='/static/app/devices/icon/x24/{{ groupDevice.image || "E30HT.jpg" }}')


### PR DESCRIPTION
Without these changes, the dropdown occluded the buttons area:

![screen shot 2015-09-28 at 10 26 02 am](https://cloud.githubusercontent.com/assets/1577721/10148583/a7705144-660a-11e5-86bd-fa4fe89a0d39.png)

A few CSS tweaks solves it:

![screen shot 2015-09-28 at 6 00 08 pm](https://cloud.githubusercontent.com/assets/1577721/10148608/c9be7a6e-660a-11e5-8f63-105e09a29125.png)

Dropdown functionality works correctly.

