### PR TITLE
Also allow shift-click standalone mode on device icon

### DIFF
--- a/res/app/device-list/icons/device-list-icons-directive.js
+++ b/res/app/device-list/icons/device-list-icons-directive.js
@@ -1,6 +1,6 @@
 var patchArray = require('./../util/patch-array')
 
-module.exports = function DeviceListDetailsDirective(
+module.exports = function DeviceListIconsDirective(
   $filter
 , gettext
 , DeviceColumnService

--- a/res/app/device-list/icons/device-list-icons-directive.js
+++ b/res/app/device-list/icons/device-list-icons-directive.js
@@ -140,6 +140,8 @@ module.exports = function DeviceListDetailsDirective(
           e.target.classList.contains('device-photo-small') ||
           e.target.classList.contains('device-name')) {
           id = e.target.parentNode.parentNode.id
+        } else if (e.target.parentNode.classList.contains('device-photo-small')) {
+          id = e.target.parentNode.parentNode.parentNode.id
         }
 
         if (id) {


### PR DESCRIPTION
Currently, shift-click does not work if click event is made on device icon. This fix will allow to start device remote control on standalone mode even click is made on device icon.