### PR TITLE
Fix https://github.com/openstf/stf/issues/184

### DIFF
--- a/res/app/components/stf/screen/screen-directive.js
+++ b/res/app/components/stf/screen/screen-directive.js
@@ -383,7 +383,6 @@ module.exports = function DeviceScreenDirective(
             'letterboxed', parentAspect < canvasAspect)
         }
 
-        $window.addEventListener('beforeunload', stop, false)
         $window.addEventListener('resize', resizeListener, false)
         scope.$on('fa-pane-resize', resizeListener)
 
@@ -391,7 +390,6 @@ module.exports = function DeviceScreenDirective(
 
         scope.$on('$destroy', function() {
           stop()
-          $window.removeEventListener('beforeunload', stop, false)
           $window.removeEventListener('resize', resizeListener, false)
         })
       })()


### PR DESCRIPTION
Issue: https://github.com/openstf/stf/issues/184

The reason of the bug was, on saving screenshot download dialogue will comeup and it will call window.onbeforeunload event.

Currently, `onbeforeunload` is calling `stop` function which is closing webscoket connection. Due to this screen is freezing.
