### PR TITLE
SAML2.0 support for authorisation

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -482,6 +482,63 @@ program
     })
   })
 
+  program
+    .command('auth-saml2')
+    .description('start SAML 2.0 auth client')
+    .option('-p, --port <port>'
+      , 'port (or $PORT)'
+      , Number
+      , process.env.PORT || 7120)
+    .option('-s, --secret <secret>'
+      , 'secret (or $SECRET)'
+      , String
+      , process.env.SECRET)
+    .option('-i, --ssid <ssid>'
+      , 'session SSID (or $SSID)'
+      , String
+      , process.env.SSID || 'ssid')
+    .option('-a, --app-url <url>'
+      , 'URL to app'
+      , String)
+    .option('--saml-id-provider-entry-point-url <url>'
+      , 'SAML 2.0 identity provider URL (or $SAML_ID_PROVIDER_ENTRY_POINT_URL)'
+      , String
+      , process.env.SAML_ID_PROVIDER_ENTRY_POINT_URL)
+    .option('--saml-id-provider-issuer <issuer>'
+      , 'SAML 2.0 identity provider issuer (or $SAML_ID_PROVIDER_ISSUER)'
+      , String
+      , process.env.SAML_ID_PROVIDER_ISSUER)
+    .option('--saml-id-provider-cert-path <path>'
+      , 'SAML 2.0 identity provider certificate file path (or $SAML_ID_PROVIDER_CERT_PATH)'
+      , String
+      , process.env.SAML_ID_PROVIDER_CERT_PATH)
+    .action(function(options) {
+      if (!options.secret) {
+        this.missingArgument('--secret')
+      }
+      if (!options.appUrl) {
+        this.missingArgument('--app-url')
+      }
+      if (!options.samlIdProviderEntryPointUrl) {
+        this.missingArgument('--saml-id-provider-entry-point-url')
+      }
+      if (!options.samlIdProviderIssuer) {
+        this.missingArgument('--saml-id-provider-issuer')
+      }
+
+      require('./units/auth/saml2')({
+        port: options.port
+      , secret: options.secret
+      , ssid: options.ssid
+      , appUrl: options.appUrl
+      , saml: {
+          entryPoint: options.samlIdProviderEntryPointUrl
+        , issuer: options.samlIdProviderIssuer
+        , certPath: options.samlIdProviderCertPath
+        }
+      })
+    })
+
 program
   .command('auth-mock')
   .description('start mock auth client')
@@ -918,7 +975,7 @@ program
     , 'device pull endpoint'
     , String
     , 'tcp://127.0.0.1:7116')
-  .option('--auth-type <mock|ldap|oauth2>'
+  .option('--auth-type <mock|ldap|oauth2|saml2>'
     , 'auth type'
     , String
     , 'mock')
@@ -1099,7 +1156,7 @@ program
               'http://%s:%d/auth/%s/'
             , options.publicIp
             , options.poorxyPort
-            , ({oauth2: 'oauth'}[options.authType]) || options.authType
+            , ({oauth2: 'oauth', saml2: 'saml'}[options.authType]) || options.authType
             )
           , '--websocket-url', util.format(
               'http://%s:%d/'

--- a/lib/units/auth/saml2.js
+++ b/lib/units/auth/saml2.js
@@ -1,0 +1,80 @@
+var fs = require('fs')
+var http = require('http')
+
+var express = require('express')
+var passport = require('passport')
+var SamlStrategy = require('passport-saml').Strategy
+var bodyParser = require('body-parser')
+var _ = require('lodash')
+
+var logger = require('../../util/logger')
+var urlutil = require('../../util/urlutil')
+var jwtutil = require('../../util/jwtutil')
+
+module.exports = function(options) {
+  var log = logger.createLogger('auth-saml2')
+    , app = express()
+    , server = http.createServer(app)
+
+  app.set('strict routing', true)
+  app.set('case sensitive routing', true)
+  app.use(bodyParser.urlencoded({ extended: false }))
+  app.use(passport.initialize())
+
+  passport.serializeUser(function(user, done) {
+    done(null, user);
+  });
+  passport.deserializeUser(function(user, done) {
+    done(null, user);
+  });
+
+  var verify = function(profile, done) {
+    return done(null, profile)
+  }
+
+  var samlConfig = {
+    path: '/auth/saml/callback'
+  , entryPoint: options.saml.entryPoint
+  , issuer: options.saml.issuer
+  }
+
+  if (options.saml.certPath) {
+    samlConfig = _.merge(samlConfig, {
+      cert: fs.readFileSync(options.saml.certPath).toString()
+    })
+  }
+
+  passport.use(new SamlStrategy(samlConfig, verify))
+
+  app.use(passport.authenticate('saml', {
+    failureRedirect: '/auth/saml/'
+  , session: false
+  }))
+
+  app.post(
+    '/auth/saml/callback'
+  , function(req, res) {
+      if (req.user.email) {
+        res.redirect(urlutil.addParams(options.appUrl, {
+          jwt: jwtutil.encode({
+            payload: {
+              email: req.user.email
+            , name: req.user.email.split('@', 1).join('')
+            }
+          , secret: options.secret
+          , header: {
+              exp: Date.now() + 24 * 3600
+            }
+          })
+        }))
+      }
+      else {
+        log.warn('Missing email in profile', req.user)
+        res.redirect('/auth/saml/')
+      }
+    }
+  )
+
+  server.listen(options.port)
+  log.info('Listening on port %d', options.port)
+}

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "node-uuid": "^1.4.3",
     "passport": "^0.3.2",
     "passport-oauth2": "^1.1.2",
+    "passport-saml": "^0.14.0",
     "protobufjs": "^3.8.2",
     "proxy-addr": "^1.0.10",
     "request": "^2.67.0",


### PR DESCRIPTION
Sample Usage

```bash
stf local --auth-type saml2 \
    --auth-options '["--saml-id-provider-entry-point-url", "YOUR_ID_PROVIDER_URL", "--saml-id-provider-issuer", "YOUR_ID_PROVIDER_ISSUER"]'
```