### PR TITLE
Add optional basic authentication in auth-mock

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -557,6 +557,16 @@ program
   .option('-a, --app-url <url>'
     , 'URL to app'
     , String)
+  .option('--use-basic-auth'
+    , 'Whether to use basic authentication for login or not')
+  .option('--basic-auth-username <username>'
+    , 'Basic Auth Username (or $BASIC_AUTH_USERNAME)'
+    , String
+    , process.env.BASIC_AUTH_USERNAME || 'username')
+  .option('--basic-auth-password <password>'
+    , 'Basic Auth Password (or $BASIC_AUTH_PASSWORD)'
+    , String
+    , process.env.BASIC_AUTH_PASSWORD || 'password')
   .action(function(options) {
     if (!options.secret) {
       this.missingArgument('--secret')
@@ -570,6 +580,13 @@ program
     , secret: options.secret
     , ssid: options.ssid
     , appUrl: options.appUrl
+    , mock: {
+        useBasicAuth: options.useBasicAuth
+      , basicAuth: {
+          username: options.basicAuthUsername
+        , password: options.basicAuthPassword
+        }
+      }
     })
   })
 

--- a/lib/units/auth/mock.js
+++ b/lib/units/auth/mock.js
@@ -7,6 +7,7 @@ var bodyParser = require('body-parser')
 var serveStatic = require('serve-static')
 var csrf = require('csurf')
 var Promise = require('bluebird')
+var basicAuth = require('basic-auth')
 
 var logger = require('../../util/logger')
 var requtil = require('../../util/requtil')
@@ -28,6 +29,27 @@ module.exports = function(options) {
       })
   })
 
+  // BasicAuth Middleware
+  var basicAuthMiddleware = function(req, res, next) {
+    function unauthorized(res) {
+      res.set('WWW-Authenticate', 'Basic realm=Authorization Required')
+      return res.send(401)
+    }
+
+    var user = basicAuth(req)
+
+    if (!user || !user.name || !user.pass) {
+      return unauthorized(res)
+    }
+
+    if (user.name === options.mock.basicAuth.username &&
+        user.pass === options.mock.basicAuth.password) {
+      return next()
+    } else {
+      return unauthorized(res)
+    }
+  }
+
   app.set('view engine', 'jade')
   app.set('views', pathutil.resource('auth/mock/views'))
   app.set('strict routing', true)
@@ -48,6 +70,10 @@ module.exports = function(options) {
     res.cookie('XSRF-TOKEN', req.csrfToken())
     next()
   })
+
+  if (options.mock.useBasicAuth) {
+    app.use(basicAuthMiddleware)
+  }
 
   app.get('/', function(req, res) {
     res.redirect('/auth/mock/')

--- a/lib/units/auth/mock.js
+++ b/lib/units/auth/mock.js
@@ -45,7 +45,8 @@ module.exports = function(options) {
     if (user.name === options.mock.basicAuth.username &&
         user.pass === options.mock.basicAuth.password) {
       return next()
-    } else {
+    }
+    else {
       return unauthorized(res)
     }
   }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "adbkit-apkreader": "^1.0.0",
     "adbkit-monkey": "^1.0.1",
     "aws-sdk": "^2.2.3",
+    "basic-auth": "^1.0.3",
     "bluebird": "^2.9.34",
     "body-parser": "^1.13.3",
     "bufferutil": "^1.2.1",


### PR DESCRIPTION
This PR will add optional basic authentication in `auth-mock` unit.

**Use Case** 
Many of stf users are still using `auth-mock` in their setup. Ideally they should not be using it. With current `auth-mock`, anyone would be able to use stf who has access to URL.

This optional basic auth will add a minute layer of security. If the admin uses this option, only people who have username and password would be able to see login screen.

**Usage**
```bash
BASIC_AUTH_USERNAME=hogehoge BASIC_AUTH_PASSWORD=fogefoge stf local --auth-options '["--use-basic-auth"]'
```