### PR TITLE
Save initialPackages in DB instead of memory

### DIFF
--- a/lib/db/api.js
+++ b/lib/db/api.js
@@ -176,6 +176,12 @@ dbapi.setDeviceOwner = function(serial, owner) {
   }))
 }
 
+dbapi.saveDeviceInitialPackages = function(serial, packages) {
+  return db.run(r.table('devices').get(serial).update({
+    initialPackages: packages
+  }))
+}
+
 dbapi.unsetDeviceOwner = function(serial) {
   return db.run(r.table('devices').get(serial).update({
     owner: null

--- a/lib/units/device/plugins/cleanup.js
+++ b/lib/units/device/plugins/cleanup.js
@@ -3,12 +3,16 @@ var Promise = require('bluebird')
 var _ = require('lodash')
 
 var logger = require('../../../util/logger')
+var wire = require('../../../wire')
+var wireutil = require('../../../wire/util')
 
 module.exports = syrup.serial()
   .dependency(require('../support/adb'))
   .dependency(require('../resources/service'))
   .dependency(require('./group'))
-  .define(function(options, adb, service, group) {
+  .dependency(require('../support/router'))
+  .dependency(require('../support/push'))
+  .define(function(options, adb, service, group, router, push) {
     var log = logger.createLogger('device:plugins:cleanup')
     var plugin = Object.create(null)
 
@@ -25,17 +29,34 @@ module.exports = syrup.serial()
         })
     }
 
+    router.on(wire.InitialPackagesReceivedMessage, function(channel, message) {
+      listPackages()
+        .then(function(currentPackages) {
+          var remove = _.difference(currentPackages, message.packageNames)
+          return Promise.map(remove, uninstallPackage)
+        })
+    })
+
+    plugin.removePackages = function() {
+      push.send([
+        wireutil.global
+      , wireutil.envelope(new wire.InitialPackagesGetMessage(
+          options.serial
+        ))
+      ])
+    }
+
     return listPackages()
       .then(function(initialPackages) {
         initialPackages.push(service.pkg)
 
-        plugin.removePackages = function() {
-          return listPackages()
-            .then(function(currentPackages) {
-              var remove = _.difference(currentPackages, initialPackages)
-              return Promise.map(remove, uninstallPackage)
-            })
-        }
+        push.send([
+          wireutil.global
+        , wireutil.envelope(new wire.InitialPackagesSaveMessage(
+            options.serial
+          , initialPackages
+          ))
+        ])
 
         group.on('leave', function() {
           plugin.removePackages()

--- a/lib/units/processor/index.js
+++ b/lib/units/processor/index.js
@@ -217,6 +217,27 @@ module.exports = function(options) {
       dbapi.setDeviceReverseForwards(message.serial, message.forwards)
       appDealer.send([channel, data])
     })
+    .on(wire.InitialPackagesSaveMessage, function(channel, message, data) {
+      dbapi.saveDeviceInitialPackages(message.serial, message.packageNames)
+    })
+    .on(wire.InitialPackagesGetMessage, function(channel, message, data) {
+      dbapi.loadDevice(message.serial)
+        .then(function(device) {
+          devDealer.send([
+            device.channel
+          , wireutil.envelope(new wire.InitialPackagesReceivedMessage(
+              device.initialPackages
+            ))
+          ])
+        })
+        .catch(function(err) {
+          log.error(
+            'Unable to load device "%s"'
+          , message.serial
+          , err.stack
+          )
+        })
+    })
     .handler())
 
   lifecycle.observe(function() {

--- a/lib/wire/wire.proto
+++ b/lib/wire/wire.proto
@@ -76,6 +76,9 @@ enum MessageType {
   ReverseForwardsEvent       = 72;
   FileSystemListMessage      = 81;
   FileSystemGetMessage       = 82;
+  InitialPackagesSaveMessage = 92;
+  InitialPackagesGetMessage  = 93;
+  InitialPackagesReceivedMessage = 94;
 }
 
 message FileSystemListMessage {
@@ -550,4 +553,17 @@ message PhoneStateEvent {
 message RotationEvent {
   required string serial = 1;
   required int32 rotation = 2;
+}
+
+message InitialPackagesSaveMessage {
+  required string serial = 1;
+  repeated string packageNames = 2;
+}
+
+message InitialPackagesGetMessage {
+  required string serial = 1;
+}
+
+message InitialPackagesReceivedMessage {
+  repeated string packageNames = 2;
 }


### PR DESCRIPTION
Currently initialPackages are stored in Memory. This PR will save initialPackages in DB instead.

As such there won't be big difference, this PR will just increase reliability of cleanup process.
