### PR TITLE
This fixes bug with leaking ports when emulator or device is rebooted

### DIFF
--- a/lib/units/provider/index.js
+++ b/lib/units/provider/index.js
@@ -232,6 +232,7 @@ module.exports = function(options) {
         lists.waiting.push(device.id)
 
         return resolver.promise
+          .cancellable()
           .finally(function() {
             log.info('Cleaning up device worker "%s"', device.id)
 
@@ -246,7 +247,6 @@ module.exports = function(options) {
             _.pull(lists.ready, device.id)
             _.pull(lists.waiting, device.id)
           })
-          .cancellable()
           .catch(Promise.CancellationError, function() {
             log.info('Gracefully killing device worker "%s"', device.id)
             return procutil.gracefullyKill(proc, options.killTimeout)


### PR DESCRIPTION
Change handler order for device worker promise