### PR TITLE
Fix worker restart when stopping

### DIFF
--- a/lib/units/provider/index.js
+++ b/lib/units/provider/index.js
@@ -320,6 +320,7 @@ module.exports = function(options) {
           }
         }
         else {
+          willStop = true
           stop()
         }
       }


### PR DESCRIPTION
Hi!
When [check()](https://github.com/openstf/stf/blob/master/lib/units/provider/index.js#L304) executed with values `device.present = false` and `willStop = false`:
```node
function check() {
  clearTimeout(timer)
  if (device.present) {
    <...>
  }
  else {
    stop()
  }
}
```
from [stop()](https://github.com/openstf/stf/blob/master/lib/units/provider/index.js#L296) started `worker.cancel()`:
```node
function stop() {
  if (worker) {
    log.info('Shutting down device worker "%s"', device.id)
    worker.cancel()
  }
}
```
get into [catch(Promise.CancellationError, function()](https://github.com/openstf/stf/blob/master/lib/units/provider/index.js#L250) starting `procutil.gracefullyKill`:
```node
.catch(Promise.CancellationError, function() {
  log.info('Gracefully killing device worker "%s"', device.id)
  return procutil.gracefullyKill(proc, options.killTimeout)
})
```
and if in `procutil.gracefullyKill` will error, get into [catch(procutil.ExitError, function(err)](https://github.com/openstf/stf/blob/master/lib/units/provider/index.js#L279):
```node
.catch(procutil.ExitError, function(err) {
  if (!willStop) {
    log.error(
      'Device worker "%s" died with code %s'
      , device.id
      , err.code
    )
    log.info('Restarting device worker "%s"', device.id)
    return Promise.delay(500)
      .then(function() {
        return work()
      })
  }
})
```
since value `willStop = false` worker endlessly restarts.
I'm not sure that properly understood the provider logic, but this small fix helped me.