### PR TITLE
Device stats plugin feature

### DIFF
--- a/lib/db/api.js
+++ b/lib/db/api.js
@@ -349,4 +349,24 @@ dbapi.loadAccessToken = function(id) {
   return db.run(r.table('accessTokens').get(id))
 }
 
+dbapi.markStartOfDeviceUsage = function(leaseId, group, deviceMetadata, startsFrom, endsAt) {
+  return db.run(r.table('users').get(group.email))
+    .then(function(user) {
+        return db.run(r.table('deviceUsageStats').insert({
+          leaseId
+          , device: user.settings.lastUsedDevice
+          , owner: group.email
+          , startsFrom
+          , endsAt
+          , deviceMetadata
+          }))
+      })
+}
+
+dbapi.markEndOfDeviceUsage = function(leaseId, endsAt) {
+  return db.run(r.table('deviceUsageStats').filter({leaseId}).orderBy(r.desc('startsFrom')).limit(1).update({
+    endsAt
+  }))
+}
+
 module.exports = dbapi

--- a/lib/db/tables.js
+++ b/lib/db/tables.js
@@ -54,4 +54,7 @@ module.exports = {
 , logs: {
     primaryKey: 'id'
   }
+, deviceUsageStats: {
+    primaryKey: 'leaseId'
+  }
 }

--- a/lib/units/device/index.js
+++ b/lib/units/device/index.js
@@ -40,6 +40,7 @@ module.exports = function(options) {
         .dependency(require('./plugins/wifi'))
         .dependency(require('./plugins/sd'))
         .dependency(require('./plugins/filesystem'))
+        .dependency(require('./plugins/stats'))
         .define(function(options, heartbeat, solo) {
           if (process.send) {
             // Only if we have a parent process

--- a/lib/units/device/plugins/stats/index.js
+++ b/lib/units/device/plugins/stats/index.js
@@ -1,0 +1,52 @@
+var events = require('events')
+
+var Promise = require('bluebird')
+var syrup = require('stf-syrup')
+
+var logger = require('../../../../util/logger')
+var dbapi = require('../../../../db/api')
+var uuid = require('node-uuid')
+// FIXME: make this lease map persistent
+var serialLeaseMap = {}
+const defaultIntervalMinutes = 5
+
+var updateDeviceLastSeen = (leaseId, serial) => {
+  if (serialLeaseMap[serial]) {
+    dbapi.markEndOfDeviceUsage(serialLeaseMap[serial], new Date())
+    // schedule next update
+    setTimeout( () => {updateDeviceLastSeen(leaseId, serial)}, defaultIntervalMinutes * 60 * 1000)
+  }
+}
+
+module.exports = syrup.serial()
+  .dependency(require('../group'))
+  .define(function(options, group) {
+    var log = logger.createLogger('device:plugins:stats')
+    var plugin = new events.EventEmitter()
+    
+    group.on('join', function(currentGroup, identifier) {
+      dbapi.loadDevice(options.serial)
+        .then(function (device) {
+          serialLeaseMap[options.serial] = uuid.v4()
+          var startAt = new Date()
+          var defaultEndsAt = new Date(startAt.getTime() + defaultIntervalMinutes * 60 * 1000)
+          log.info('Created new lease id', serialLeaseMap[options.serial])
+          dbapi.markStartOfDeviceUsage(serialLeaseMap[options.serial], currentGroup, device, startAt, defaultEndsAt)
+
+          // update every x minutes
+          setTimeout( () => {updateDeviceLastSeen(serialLeaseMap[options.serial], options.serial)}, defaultIntervalMinutes * 60 * 1000)
+         })
+    })
+
+    group.on('leave', function(currentGroup) {
+      log.info('updateDeviceUsage')
+      if (serialLeaseMap[options.serial]) {
+        dbapi.markEndOfDeviceUsage(serialLeaseMap[options.serial], new Date())
+        delete serialLeaseMap[options.serial]
+      } else {
+          log.info('Cannot found previous usage for device serial', options.serial)
+      }
+    })
+
+    return Promise.resolve()
+  })


### PR DESCRIPTION
This plugin store device metadata along startsFrom and EndsAt datetime for device usage. EndsAt datetime is updated every 5 minutes via setTimeout.

By using the stats data, we can derive chart of popular devices (model, OS, etc), how many minutes spend, and also most active user.

This kind of data will be useful to analyze the value of our openSTF installation.

Potential issue:
`leaseId` is not unique enough (eventhough generated from `uuid.v4` ) and may overlap after some time. 