### PR TITLE
Save uploaded files in optional --save-dir directory

### DIFF
--- a/lib/units/storage/temp.js
+++ b/lib/units/storage/temp.js
@@ -84,6 +84,9 @@ module.exports = function(options) {
 
   app.post('/s/upload/:plugin', function(req, res) {
     var form = new formidable.IncomingForm()
+    if (options.saveDir) {
+      form.uploadDir = options.saveDir
+    }
     Promise.promisify(form.parse, form)(req)
       .spread(function(fields, files) {
         return Object.keys(files).map(function(field) {


### PR DESCRIPTION
`--save-dir` option was there in `storage-temp` unit but it was not being used. Wasn't sure about real intention behind this option. This will give users to save all their uploaded files in a more persistent storage. 