### PR TITLE
Use automation label in device list for devices accessed using API

### DIFF
--- a/lib/db/api.js
+++ b/lib/db/api.js
@@ -153,6 +153,7 @@ dbapi.saveDeviceInitialState = function(serial, device) {
   , reverseForwards: []
   , remoteConnect: false
   , remoteConnectUrl: null
+  , usage: null
   }
   return db.run(r.table('devices').get(serial).update(data))
     .then(function(stats) {
@@ -209,6 +210,20 @@ dbapi.setDeviceAbsent = function(serial) {
   return db.run(r.table('devices').get(serial).update({
     present: false
   , presenceChangedAt: r.now()
+  }))
+}
+
+dbapi.setDeviceUsage = function(serial, usage) {
+  return db.run(r.table('devices').get(serial).update({
+    usage: usage
+  , usageChangedAt: r.now()
+  }))
+}
+
+dbapi.unsetDeviceUsage = function(serial) {
+  return db.run(r.table('devices').get(serial).update({
+    usage: null
+  , usageChangedAt: r.now()
   }))
 }
 

--- a/lib/units/api/controllers/user.js
+++ b/lib/units/api/controllers/user.js
@@ -148,6 +148,7 @@ function addUserDevice(req, res) {
         .handler()
 
       req.options.channelRouter.on(wireutil.global, messageListener)
+      var usage = 'automation'
 
       req.options.push.send([
         device.channel
@@ -165,6 +166,7 @@ function addUserDevice(req, res) {
             , match: 'exact'
             }
           })
+          , usage
           )
         )
       ])

--- a/lib/units/device/plugins/group.js
+++ b/lib/units/device/plugins/group.js
@@ -30,7 +30,7 @@ module.exports = syrup.serial()
       return currentGroup
     })
 
-    plugin.join = function(newGroup, timeout, identifier) {
+    plugin.join = function(newGroup, timeout, usage) {
       return plugin.get()
         .then(function() {
           if (currentGroup.group !== newGroup.group) {
@@ -57,10 +57,11 @@ module.exports = syrup.serial()
           , wireutil.envelope(new wire.JoinGroupMessage(
               options.serial
             , currentGroup
+            , usage
             ))
           ])
 
-          plugin.emit('join', currentGroup, identifier)
+          plugin.emit('join', currentGroup)
 
           return currentGroup
         })
@@ -113,7 +114,7 @@ module.exports = syrup.serial()
         var reply = wireutil.reply(options.serial)
         grouputil.match(ident, message.requirements)
           .then(function() {
-            return plugin.join(message.owner, message.timeout)
+            return plugin.join(message.owner, message.timeout, message.usage)
           })
           .then(function() {
             push.send([

--- a/lib/units/processor/index.js
+++ b/lib/units/processor/index.js
@@ -175,10 +175,14 @@ module.exports = function(options) {
     })
     .on(wire.JoinGroupMessage, function(channel, message, data) {
       dbapi.setDeviceOwner(message.serial, message.owner)
+      if (message.usage) {
+        dbapi.setDeviceUsage(message.serial, message.usage)
+      }
       appDealer.send([channel, data])
     })
     .on(wire.LeaveGroupMessage, function(channel, message, data) {
       dbapi.unsetDeviceOwner(message.serial, message.owner)
+      dbapi.unsetDeviceUsage(message.serial)
       appDealer.send([channel, data])
     })
     .on(wire.DeviceLogMessage, function(channel, message, data) {

--- a/lib/units/websocket/index.js
+++ b/lib/units/websocket/index.js
@@ -174,6 +174,7 @@ module.exports = function(options) {
               serial: message.serial
             , owner: message.owner
             , likelyLeaveReason: 'owner_change'
+            , usage: message.usage
             }
           , user
           )

--- a/lib/units/websocket/index.js
+++ b/lib/units/websocket/index.js
@@ -397,8 +397,15 @@ module.exports = function(options) {
               , wireutil.envelope(new wire.AdbKeysUpdatedMessage())
               ])
             })
-            .catch(dbapi.DuplicateSecondaryIndexError, function() {
-              // No-op
+            .catch(dbapi.DuplicateSecondaryIndexError, function(err) {
+              socket.emit('user.keys.adb.error', {
+                message: 'Someone already added this key'
+              })
+            })
+            .catch(Error, function(err) {
+              socket.emit('user.keys.adb.error', {
+                message: err.message
+              })
             })
         })
         .on('user.keys.adb.accept', function(data) {

--- a/lib/wire/wire.proto
+++ b/lib/wire/wire.proto
@@ -261,6 +261,7 @@ message GroupMessage {
   required OwnerMessage owner = 1;
   optional uint32 timeout = 2;
   repeated DeviceRequirement requirements = 3;
+  optional string usage = 4;
 }
 
 message AutoGroupMessage {
@@ -275,6 +276,7 @@ message UngroupMessage {
 message JoinGroupMessage {
   required string serial = 1;
   required OwnerMessage owner = 2;
+  optional string usage = 3;
 }
 
 message JoinGroupByAdbFingerprintMessage {

--- a/res/app/components/stf/device/device-info-filter/index.js
+++ b/res/app/components/stf/device/device-info-filter/index.js
@@ -10,7 +10,8 @@ module.exports = angular.module('stf.device-status', [])
         ready: gettext('Ready'),
         using: gettext('Stop Using'),
         busy: gettext('Busy'),
-        available: gettext('Use')
+        available: gettext('Use'),
+        automation: gettext('Stop Automation')
       }[text] || gettext('Unknown')
     }
   })
@@ -25,7 +26,8 @@ module.exports = angular.module('stf.device-status', [])
         ready: gettext('Ready'),
         using: gettext('Using'),
         busy: gettext('Busy'),
-        available: gettext('Available')
+        available: gettext('Available'),
+        automation: gettext('Automating'),
       }[text] || gettext('Unknown')
     }
   })

--- a/res/app/components/stf/device/enhance-device/enhance-device-service.js
+++ b/res/app/components/stf/device/enhance-device/enhance-device-service.js
@@ -19,7 +19,12 @@ module.exports = function EnhanceDeviceServiceFactory($filter, AppState) {
           if (data.ready) {
             data.state = 'ready'
             if (data.using) {
-              data.state = 'using'
+              if (data.usage === 'automation') {
+                data.state = 'automation'
+              }
+              else {
+                data.state = 'using'
+              }
             }
             else {
               if (data.owner) {

--- a/res/app/components/stf/device/state-classes-service.js
+++ b/res/app/components/stf/device/state-classes-service.js
@@ -10,7 +10,8 @@ module.exports = function StateClassesService() {
       present: 'state-present btn-primary-outline',
       preparing: 'state-preparing btn-primary-outline btn-success-outline',
       unauthorized: 'state-unauthorized btn-danger-outline',
-      offline: 'state-offline btn-warning-outline'
+      offline: 'state-offline btn-warning-outline',
+      automation: 'state-automation btn-info'
     }[state]
     if (typeof stateClasses === 'undefined') {
       stateClasses = 'btn-default-outline'
@@ -27,7 +28,8 @@ module.exports = function StateClassesService() {
       present: 'state-present',
       preparing: 'state-preparing',
       unauthorized: 'state-unauthorized',
-      offline: 'state-offline'
+      offline: 'state-offline',
+      automation: 'state-automation'
     }[state]
     if (typeof stateClasses === 'undefined') {
       stateClasses = ''
@@ -37,4 +39,3 @@ module.exports = function StateClassesService() {
 
   return service
 }
-

--- a/res/app/components/stf/keys/add-adb-key/add-adb-key-directive.js
+++ b/res/app/components/stf/keys/add-adb-key/add-adb-key-directive.js
@@ -13,12 +13,21 @@ module.exports = function addAdbKeyDirective(AdbKeysService) {
       , key: ''
       }
 
+      $scope.$on('user.keys.adb.error', function(event, error) {
+        $scope.$apply(function() {
+          $scope.error = error.message
+        })
+      })
+
+      $scope.$on('user.keys.adb.updated', function() {
+        $scope.closeAddKey()
+      })
+
       $scope.addKey = function() {
         UserService.addAdbKey({
           title: $scope.addForm.title
         , key: $scope.addForm.key
         })
-        $scope.closeAddKey()
       }
 
       $scope.closeAddKey = function() {
@@ -27,6 +36,7 @@ module.exports = function addAdbKeyDirective(AdbKeysService) {
         // TODO: cannot access to the form by name inside a directive?
         //$scope.adbkeyform.$setPristine()
         $scope.showAdd = false
+        $scope.error = ''
       }
     },
     link: function(scope) {

--- a/res/app/components/stf/keys/add-adb-key/add-adb-key.css
+++ b/res/app/components/stf/keys/add-adb-key/add-adb-key.css
@@ -1,3 +1,7 @@
-.stf-add-adb-key {
+.stf-add-adb-key .form-adb-key {
+  margin-bottom: 60px;
+}
 
+.stf-add-adb-key .clip-board {
+  margin-bottom: 20px;
 }

--- a/res/app/components/stf/keys/add-adb-key/add-adb-key.pug
+++ b/res/app/components/stf/keys/add-adb-key/add-adb-key.pug
@@ -2,9 +2,9 @@
   .panel-heading
     h3.panel-title(translate) Add ADB Key
   .panel-body
-    form.form-horizontal(name='adbkeyform', ng-submit='addKey(key)')
+    form.form-horizontal.stf-add-adb-key.form-adb-key(name='adbkeyform', ng-submit='addKey(key)')
 
-      div(ng-show='showClipboard')
+      .stf-add-adb-key.clip-board(ng-show='showClipboard')
 
         .alert.alert-info.selectable
           strong(translate) Tip:
@@ -12,8 +12,6 @@
           span(translate) Run this command to copy the key to your clipboard
           textarea(readonly, rows='1', text-focus-select, ng-copy='focusAddKey = true'
           ).form-control.remote-debug-textarea pbcopy < ~/.android/adbkey.pub
-
-      br
 
       .form-group
         label.control-label(for='adb-device-key')
@@ -36,7 +34,5 @@
         i.fa.fa-plus.fa-fw
         span(translate) Add Key
 
-      br
-      br
 
     error-message(message='{{error}}')

--- a/res/app/components/stf/keys/add-adb-key/add-adb-key.pug
+++ b/res/app/components/stf/keys/add-adb-key/add-adb-key.pug
@@ -36,4 +36,7 @@
         i.fa.fa-plus.fa-fw
         span(translate) Add Key
 
+      br
+      br
+
     error-message(message='{{error}}')

--- a/res/app/components/stf/user/user-service.js
+++ b/res/app/components/stf/user/user-service.js
@@ -24,6 +24,10 @@ module.exports = function UserServiceFactory(
     socket.emit('user.keys.adb.remove', key)
   }
 
+  socket.on('user.keys.adb.error', function(error) {
+    $rootScope.$broadcast('user.keys.adb.error', error)
+  })
+
   socket.on('user.keys.adb.added', function(key) {
     UserService.getAdbKeys().push(key)
     $rootScope.$broadcast('user.keys.adb.updated', user.adbKeys)

--- a/res/app/device-list/column/device-column-service.js
+++ b/res/app/device-list/column/device-column-service.js
@@ -571,6 +571,7 @@ function DeviceStatusCell(options) {
   , preparing: 'state-preparing btn-primary-outline btn-success-outline'
   , unauthorized: 'state-unauthorized btn-danger-outline'
   , offline: 'state-offline btn-warning-outline'
+  , automation: 'state-automation btn-info'
   }
 
   return _.defaults(options, {

--- a/res/app/device-list/icons/device-list-icons-directive.js
+++ b/res/app/device-list/icons/device-list-icons-directive.js
@@ -66,7 +66,8 @@ module.exports = function DeviceListIconsDirective(
             present: 'state-present btn-primary-outline',
             preparing: 'state-preparing btn-primary-outline btn-success-outline',
             unauthorized: 'state-unauthorized btn-danger-outline',
-            offline: 'state-offline btn-warning-outline'
+            offline: 'state-offline btn-warning-outline',
+            automation: 'state-automation btn-info'
           }[state]
           if (typeof stateClasses === 'undefined') {
             stateClasses = 'btn-default-outline'


### PR DESCRIPTION
User will see `Stop Automation` label for devices accessed using API instead of `Stop Using` 


<img width="275" alt="screen shot 2016-11-23 at 6 42 47 am" src="https://cloud.githubusercontent.com/assets/7875161/20548346/be20ee28-b148-11e6-961a-adab770b0439.png">
