### PR TITLE
Optional email domain restriction added for OAuth2 authorization.

### DIFF
--- a/lib/cli/auth-oauth2/index.js
+++ b/lib/cli/auth-oauth2/index.js
@@ -54,6 +54,12 @@ module.exports.builder = function(yargs) {
     , default: process.env.OAUTH_SCOPE
     , demand: true
     })
+    .option('oauth-domain', {
+      describe: 'Optional email domain to allow authentication for.'
+    , type: 'string'
+    , default: process.env.OAUTH_DOMAIN
+    , demand: false
+    })
     .option('port', {
       alias: 'p'
     , describe: 'The port to bind to.'
@@ -89,6 +95,7 @@ module.exports.handler = function(argv) {
   , secret: argv.secret
   , ssid: argv.ssid
   , appUrl: argv.appUrl
+  , domain: argv.oauthDomain
   , oauth: {
       authorizationURL: argv.oauthAuthorizationUrl
     , tokenURL: argv.oauthTokenUrl

--- a/lib/units/auth/oauth2/index.js
+++ b/lib/units/auth/oauth2/index.js
@@ -28,10 +28,20 @@ module.exports = function(options) {
   , session: false
   }))
 
+  function isEmailAllowed(email) {
+    if (email) {
+      if (options.domain) {
+        return email.endsWith(options.domain)
+      }
+      return true
+    }
+    return false
+  }
+
   app.get(
     '/auth/oauth/callback'
   , function(req, res) {
-      if (req.user.email) {
+      if (isEmailAllowed(req.user.email)) {
         res.redirect(urlutil.addParams(options.appUrl, {
           jwt: jwtutil.encode({
             payload: {
@@ -46,8 +56,9 @@ module.exports = function(options) {
         }))
       }
       else {
-        log.warn('Missing email in profile', req.user)
-        res.redirect('/auth/oauth/')
+        log.warn('Missing or disallowed email in profile', req.user)
+        res.send('<html><body>Missing or rejected email address ' +
+                 '<a href="/auth/oauth/">Retry</a></body></html>')
       }
     }
   )


### PR DESCRIPTION
This PR adds ability to specify domain of authorized email addresses.
If option is not set then behavior is not changed and any (excluding missing) email address is authorized.

In case of not authorized domain (including missing email address) simple error message is shown.

This theoretically also fixes bug with infinite redirect loop in case of missing email address in response from OAuth provider. At least with Google, unconditional redirect to `/auth/oauth/` used to cause such loop, not sure if email can be missing despite `email` scope is requested and if infinite loop was also applicable to other providers.