### PR TITLE
Fixes 594 -- Allows default content-type (application/octet-stream) on path based parameter operations

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -287,7 +287,7 @@ POST /api/v1/user/devices/{serial}/remoteConnect
 Using cURL:
 
 ```bash
-curl -X POST --header "Content-Type: application/json" -H "Authorization: Bearer YOUR-TOKEN-HERE" https://stf.example.org/api/v1/user/devices/{serial}/remoteConnect
+curl -X POST -H "Authorization: Bearer YOUR-TOKEN-HERE" https://stf.example.org/api/v1/user/devices/{serial}/remoteConnect
 ```
 
 Using Node.js:
@@ -384,7 +384,7 @@ function add_device
 
 function remote_connect
 {
-    response=$(curl -X POST -H "Content-Type: application/json" \
+    response=$(curl -X POST \
                  -H "Authorization: Bearer $STF_TOKEN" \
                 $STF_URL/api/v1/user/devices/$DEVICE_SERIAL/remoteConnect)
 
@@ -404,7 +404,7 @@ function remote_connect
 
 function remove_device
 {
-    response=$(curl -X DELETE -H "Content-Type: application/json" \
+    response=$(curl -X DELETE \
                  -H "Authorization: Bearer $STF_TOKEN" \
                 $STF_URL/api/v1/user/devices/$DEVICE_SERIAL)
 

--- a/lib/units/api/swagger/api_v1.yaml
+++ b/lib/units/api/swagger/api_v1.yaml
@@ -1,6 +1,6 @@
 swagger: "2.0"
 info:
-  version: "2.0.1"
+  version: "2.3.0"
   title: Smartphone Test Farm
   description: Control and manages real Smartphone devices from browser and restful apis
   license:
@@ -16,6 +16,7 @@ schemes:
   - https
 consumes:
   - application/json
+  - application/octet-stream
 produces:
   - application/json
 tags:
@@ -124,8 +125,6 @@ paths:
       summary: Delete User Device
       description: The User Devices endpoint will request for device release from stf server. It will return request accepted if device is being used by current user
       operationId: deleteUserDeviceBySerial
-      consumes:
-        - application/octet-stream
       tags:
         - user
       parameters:
@@ -151,8 +150,6 @@ paths:
       summary: Remote Connect
       description: The device connect endpoint will request stf server to connect remotely
       operationId: remoteConnectUserDeviceBySerial
-      consumes:
-        - application/octet-stream
       tags:
         - user
       parameters:
@@ -176,8 +173,6 @@ paths:
       summary: Remote Disconnect
       description: The device connect endpoint will request stf server to disconnect remotely
       operationId: remoteDisconnectUserDeviceBySerial
-      consumes:
-        - application/octet-stream
       tags:
         - user
       parameters:

--- a/lib/units/api/swagger/api_v1.yaml
+++ b/lib/units/api/swagger/api_v1.yaml
@@ -1,6 +1,6 @@
 swagger: "2.0"
 info:
-  version: "2.0.0"
+  version: "2.0.1"
   title: Smartphone Test Farm
   description: Control and manages real Smartphone devices from browser and restful apis
   license:
@@ -124,6 +124,8 @@ paths:
       summary: Delete User Device
       description: The User Devices endpoint will request for device release from stf server. It will return request accepted if device is being used by current user
       operationId: deleteUserDeviceBySerial
+      consumes:
+        - application/octet-stream
       tags:
         - user
       parameters:
@@ -149,6 +151,8 @@ paths:
       summary: Remote Connect
       description: The device connect endpoint will request stf server to connect remotely
       operationId: remoteConnectUserDeviceBySerial
+      consumes:
+        - application/octet-stream
       tags:
         - user
       parameters:
@@ -172,6 +176,8 @@ paths:
       summary: Remote Disconnect
       description: The device connect endpoint will request stf server to disconnect remotely
       operationId: remoteDisconnectUserDeviceBySerial
+      consumes:
+        - application/octet-stream
       tags:
         - user
       parameters:

--- a/lib/units/api/swagger/api_v1_generated.json
+++ b/lib/units/api/swagger/api_v1_generated.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "2.0.0",
+    "version": "2.0.1",
     "title": "Smartphone Test Farm",
     "description": "Control and manages real Smartphone devices from browser and restful apis",
     "license": {
@@ -37,6 +37,7 @@
   ],
   "paths": {
     "/user": {
+      "x-swagger-router-controller": "user",
       "get": {
         "summary": "User Profile",
         "description": "The User Profile endpoint returns information about current authorized user",
@@ -66,6 +67,7 @@
       }
     },
     "/user/devices": {
+      "x-swagger-router-controller": "user",
       "get": {
         "summary": "User Devices",
         "description": "The User Devices endpoint returns device list owner by current authorized user",
@@ -139,6 +141,7 @@
       }
     },
     "/user/devices/{serial}": {
+      "x-swagger-router-controller": "user",
       "get": {
         "summary": "User Device",
         "description": "The devices enpoint return information about device owned by user",
@@ -186,6 +189,9 @@
         "summary": "Delete User Device",
         "description": "The User Devices endpoint will request for device release from stf server. It will return request accepted if device is being used by current user",
         "operationId": "deleteUserDeviceBySerial",
+        "consumes": [
+          "application/octet-stream"
+        ],
         "tags": [
           "user"
         ],
@@ -217,10 +223,14 @@
       }
     },
     "/user/devices/{serial}/remoteConnect": {
+      "x-swagger-router-controller": "user",
       "post": {
         "summary": "Remote Connect",
         "description": "The device connect endpoint will request stf server to connect remotely",
         "operationId": "remoteConnectUserDeviceBySerial",
+        "consumes": [
+          "application/octet-stream"
+        ],
         "tags": [
           "user"
         ],
@@ -257,6 +267,9 @@
         "summary": "Remote Disconnect",
         "description": "The device connect endpoint will request stf server to disconnect remotely",
         "operationId": "remoteDisconnectUserDeviceBySerial",
+        "consumes": [
+          "application/octet-stream"
+        ],
         "tags": [
           "user"
         ],
@@ -288,6 +301,7 @@
       }
     },
     "/user/accessTokens": {
+      "x-swagger-router-controller": "user",
       "get": {
         "summary": "Access Tokens",
         "description": "The Access Tokens endpoints returns titles of all the valid access tokens",
@@ -317,6 +331,7 @@
       }
     },
     "/devices": {
+      "x-swagger-router-controller": "devices",
       "get": {
         "summary": "Device List",
         "description": "The devices endpoint return list of all the STF devices including Disconnected and Offline",
@@ -355,6 +370,7 @@
       }
     },
     "/devices/{serial}": {
+      "x-swagger-router-controller": "devices",
       "get": {
         "summary": "Device Information",
         "description": "The device enpoint return information about a single device",
@@ -399,7 +415,9 @@
         ]
       }
     },
-    "/swagger.json": {}
+    "/swagger.json": {
+      "x-swagger-pipe": "swagger_raw"
+    }
   },
   "definitions": {
     "UserResponse": {

--- a/lib/units/api/swagger/api_v1_generated.json
+++ b/lib/units/api/swagger/api_v1_generated.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "2.0.1",
+    "version": "2.3.0",
     "title": "Smartphone Test Farm",
     "description": "Control and manages real Smartphone devices from browser and restful apis",
     "license": {
@@ -20,7 +20,8 @@
     "https"
   ],
   "consumes": [
-    "application/json"
+    "application/json",
+    "application/octet-stream"
   ],
   "produces": [
     "application/json"
@@ -189,9 +190,6 @@
         "summary": "Delete User Device",
         "description": "The User Devices endpoint will request for device release from stf server. It will return request accepted if device is being used by current user",
         "operationId": "deleteUserDeviceBySerial",
-        "consumes": [
-          "application/octet-stream"
-        ],
         "tags": [
           "user"
         ],
@@ -228,9 +226,6 @@
         "summary": "Remote Connect",
         "description": "The device connect endpoint will request stf server to connect remotely",
         "operationId": "remoteConnectUserDeviceBySerial",
-        "consumes": [
-          "application/octet-stream"
-        ],
         "tags": [
           "user"
         ],
@@ -267,9 +262,6 @@
         "summary": "Remote Disconnect",
         "description": "The device connect endpoint will request stf server to disconnect remotely",
         "operationId": "remoteDisconnectUserDeviceBySerial",
-        "consumes": [
-          "application/octet-stream"
-        ],
         "tags": [
           "user"
         ],


### PR DESCRIPTION
@vbanthia 
I took a stab at https://github.com/openstf/stf/issues/594

Appears to address the issue.