### PR TITLE
Initialize flag variable "header" to true in /lib/util/devutil.js

### DIFF
--- a/lib/util/devutil.js
+++ b/lib/util/devutil.js
@@ -42,7 +42,7 @@ devutil.listPidsByComm = function(adb, serial, comm, bin) {
   return adb.shell(serial, ['ps', comm])
     .then(function(out) {
       return new Promise(function(resolve) {
-        var header = false
+        var header = true
         var pids = []
         out.pipe(split())
           .on('data', function(chunk) {


### PR DESCRIPTION
Seems we intended to filter header line in the output of "ps comm",  it's supposed to initialize flag variable "header" to true.