### PR TITLE
replace "ps comm" with "ps" in  the function listPidsByComm

### DIFF
--- a/lib/util/devutil.js
+++ b/lib/util/devutil.js
@@ -39,7 +39,7 @@ devutil.listPidsByComm = function(adb, serial, comm, bin) {
     shell: true
   }
 
-  return adb.shell(serial, ['ps', comm])
+  return adb.shell(serial, ['ps'])
     .then(function(out) {
       return new Promise(function(resolve) {
         var header = true


### PR DESCRIPTION
There exists an incompatibility problem as the shell command "ps comm" is invalid in some devices such as Google Pixel.

Below is the output when I issued "ps com" in Pixel:

 sailfish:/ $ ps com
 bad pid 'com'
 sailfish:/ $ echo $?
 1

So I replaced "ps comm" with "ps" which is workable for all the Android device.