### PR TITLE
add new option '-exclude' in provider to exclude device with regexp pattern

### DIFF
--- a/lib/cli/local/index.js
+++ b/lib/cli/local/index.js
@@ -129,6 +129,11 @@ module.exports.builder = function(yargs) {
     , type: 'string'
     , default: os.hostname()
     })
+    .option('provider-exclude', {
+      describe: 'Pattern to exclude devices'
+      , type: 'string'
+      , default: ''
+    })
     .option('provider-max-port', {
       describe: 'Highest port number for device workers to use.'
     , type: 'number'
@@ -254,6 +259,7 @@ module.exports.handler = function(argv) {
     , procutil.fork(path.resolve(__dirname, '..'), [
           'provider'
         , '--name', argv.provider
+        , '--exclude', argv.providerExclude
         , '--min-port', argv.providerMinPort
         , '--max-port', argv.providerMaxPort
         , '--connect-sub', argv.bindDevPub

--- a/lib/cli/provider/index.js
+++ b/lib/cli/provider/index.js
@@ -56,6 +56,11 @@ module.exports.builder = function(yargs) {
     , type: 'string'
     , default: '${publicIp}:${publicPort}'
     })
+    .option('exclude', {
+      describe: 'Pattern to exclude devices'
+      , type: 'string'
+      , default: ''
+    })
     .option('group-timeout', {
       alias: 't'
     , describe: 'Timeout in seconds for automatic release of inactive devices.'
@@ -153,6 +158,9 @@ module.exports.handler = function(argv) {
   , ports: range(argv.minPort, argv.maxPort)
   , filter: function(device) {
       return argv.serial.length === 0 || argv.serial.indexOf(device.id) !== -1
+    }
+    , exclude: function(device) {
+      return argv.exclude && device.id.match(argv.exclude) !== null
     }
   , allowRemote: argv.allowRemote
   , fork: function(device, ports) {

--- a/lib/units/provider/index.js
+++ b/lib/units/provider/index.js
@@ -141,6 +141,11 @@ module.exports = function(options) {
           log.info('Filtered out device "%s"', device.id)
           return false
         }
+        if (options.exclude && options.exclude(device)) {
+          log.info('Exclude device "%s"', device.id)
+          return false
+        }
+
         return listener(device)
       }
     }


### PR DESCRIPTION
When I connected mobile devices into STF from Windows system, some emulator devices were joined unintentionally, so I added a new option "-exclude regex" in provider to exclude devices whose serials match the specified regex pattern like "^emulator.*".

Another benefit for the feature is that we can prevent multiple local devices from joining STF provider.