### PR TITLE
add bower install --allow-root

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "test": "gulp test",
-    "prepublish": "bower install && not-in-install && gulp build || in-install"
+    "prepublish": "bower install --allow-root && not-in-install && gulp build || in-install"
   },
   "dependencies": {
     "@slack/client": "^3.5.4",


### PR DESCRIPTION
To deal with the issue 'bower ESUDO         Cannot be run with sudo', add '--allow-root' in package.json file.