### PR TITLE
Add timestamp format to logger

### DIFF
--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -108,7 +108,7 @@ Log.prototype.fatal = function() {
 
 Log.prototype._entry = function(priority, args) {
   return new Log.Entry(
-      new Date
+      new Date()
     , priority
     , this.tag
     , process.pid

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -108,7 +108,7 @@ Log.prototype.fatal = function() {
 
 Log.prototype._entry = function(priority, args) {
   return new Log.Entry(
-      Date.now()
+      new Date
     , priority
     , this.tag
     , process.pid

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -1,6 +1,7 @@
 /* eslint quote-props:0 */
 var util = require('util')
 var events = require('events')
+var dateformat = require('dateformat')
 
 var chalk = require('chalk')
 
@@ -117,7 +118,8 @@ Log.prototype._entry = function(priority, args) {
 }
 
 Log.prototype._format = function(entry) {
-  return util.format('%s/%s %d [%s] %s'
+  return util.format('[%s] %s/%s %d [%s] %s'
+    , dateformat('yyyy/mm/dd HH:MM:ss')
     , this._name(entry.priority)
     , entry.tag
     , entry.pid

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "compression": "^1.5.2",
     "cookie-session": "^2.0.0-alpha.1",
     "csurf": "^1.7.0",
+    "dateformat": "^2.0.0",
     "debug": "^2.2.0",
     "eventemitter3": "^1.2.0",
     "express": "^4.14.0",


### PR DESCRIPTION
logger.js has timestamp variable but I can't use it.
This PR makes timestamp available in log.

#### example
```
[2017/10/13 22:10:59] WRN/db 15255 [*] Connection closed
[2017/10/13 22:10:59] INF/db 15255 [*] Connecting to 127.0.0.1:28015
[2017/10/13 22:11:00] WRN/db 15257 [*] Connection closed
[2017/10/13 22:11:00] INF/db 15257 [*] Connecting to 127.0.0.1:28015
[2017/10/13 22:11:00] WRN/db 15256 [*] Connection closed
[2017/10/13 22:11:00] INF/db 15256 [*] Connecting to 127.0.0.1:28015
```