### PR TITLE
[#460][#349][#19] Potential fix - Enable Screenshots functionality

### DIFF
--- a/lib/units/storage/plugins/image/task/transform.js
+++ b/lib/units/storage/plugins/image/task/transform.js
@@ -3,7 +3,6 @@ var Promise = require('bluebird')
 
 module.exports = function(stream, options) {
   return new Promise(function(resolve, reject) {
-
     var transform = gm(stream)
 
     if (options.gravity) {

--- a/lib/units/storage/plugins/image/task/transform.js
+++ b/lib/units/storage/plugins/image/task/transform.js
@@ -1,8 +1,9 @@
-var gm = require('gm')
+var gm = require('gm').subClass({imageMagick: true})
 var Promise = require('bluebird')
 
 module.exports = function(stream, options) {
   return new Promise(function(resolve, reject) {
+
     var transform = gm(stream)
 
     if (options.gravity) {

--- a/res/app/control-panes/control-panes-hotkeys-controller.js
+++ b/res/app/control-panes/control-panes-hotkeys-controller.js
@@ -57,7 +57,7 @@ module.exports =
       },
       takeScreenShot: function() {
         // TODO: Switch tab and take screenshot
-        //$scope.takeScreenShot()
+        $scope.takeScreenShot()
       },
       pressMenu: function() {
         $scope.control.menu()


### PR DESCRIPTION
Basing on commented functionality and mostly the problem with issues mentioned in https://github.com/openstf/stf/issues/460 and https://github.com/openstf/stf/issues/349 I noticed that mostly my problem was connected with not using imagemagick. Mostly I had problem with proper converting bitmap which was collected from blob.
After changing:
var gm = require('gm')
to:
var gm = require('gm').subClass({imageMagick: true})
Screenshots bitmaps are properly displayed on stf screenshot div.