### PR TITLE
Implements addAdbPublicKey API endpoint

### DIFF
--- a/lib/units/api/controllers/user.js
+++ b/lib/units/api/controllers/user.js
@@ -3,7 +3,7 @@ var util = require('util')
 var _ = require('lodash')
 var Promise = require('bluebird')
 var uuid = require('uuid')
-
+var adbkit = require('adbkit')
 var dbapi = require('../../../db/api')
 var logger = require('../../../util/logger')
 var datautil = require('../../../util/datautil')
@@ -23,6 +23,7 @@ module.exports = {
 , remoteConnectUserDeviceBySerial: remoteConnectUserDeviceBySerial
 , remoteDisconnectUserDeviceBySerial: remoteDisconnectUserDeviceBySerial
 , getUserAccessTokens: getUserAccessTokens
+, addAdbPublicKey: addAdbPublicKey
 }
 
 function getUser(req, res) {
@@ -397,6 +398,60 @@ function getUserAccessTokens(req, res) {
       log.error('Failed to load tokens: ', err.stack)
       res.status(500).json({
         success: false
+      })
+    })
+}
+
+function addAdbPublicKey(req, res) {
+  var data = req.swagger.params.adb.value
+  adbkit.util.parsePublicKey(data.publickey)
+    .then(function(key) {
+      return dbapi.lookupUsersByAdbKey(key.fingerprint)
+        .then(function(cursor) {
+          return cursor.toArray()
+        })
+        .then(function(users) {
+          return {
+            key: {
+              title: data.title || key.comment,
+              fingerprint: key.fingerprint
+            },
+            users: users
+          }
+        })
+    })
+    .then(function(data) {
+
+      if (data.users.length) {
+        return res.json({
+          success: true
+        })
+      }
+      else {
+        return dbapi.insertUserAdbKey(req.user.email, data.key)
+          .then(function() {
+            return res.json({
+              success: true
+            })
+          })
+      }
+    })
+    .then(function() {
+      req.options.push.send([
+        req.user.group
+      , wireutil.envelope(new wire.AdbKeysUpdatedMessage())
+      ])
+    })
+    .catch(dbapi.DuplicateSecondaryIndexError, function() {
+      // No-op
+      return res.json({
+        success: true
+      })
+    }).catch(function(err) {
+      log.error('Failed to insert new adb key fingerprint: ', err.stack)
+      return res.status(500).json({
+        success: false,
+        message: "Unable to insert new adb key fingerprint to database"
       })
     })
 }

--- a/lib/units/api/controllers/user.js
+++ b/lib/units/api/controllers/user.js
@@ -413,15 +413,14 @@ function addAdbPublicKey(req, res) {
         .then(function(users) {
           return {
             key: {
-              title: data.title || key.comment,
-              fingerprint: key.fingerprint
-            },
-            users: users
+              title: data.title || key.comment
+              , fingerprint: key.fingerprint
+            }
+            , users: users
           }
         })
     })
     .then(function(data) {
-
       if (data.users.length) {
         return res.json({
           success: true
@@ -450,8 +449,8 @@ function addAdbPublicKey(req, res) {
     }).catch(function(err) {
       log.error('Failed to insert new adb key fingerprint: ', err.stack)
       return res.status(500).json({
-        success: false,
-        message: "Unable to insert new adb key fingerprint to database"
+        success: false
+        , message: 'Unable to insert new adb key fingerprint to database'
       })
     })
 }

--- a/lib/units/api/controllers/user.js
+++ b/lib/units/api/controllers/user.js
@@ -414,9 +414,9 @@ function addAdbPublicKey(req, res) {
           return {
             key: {
               title: data.title || key.comment
-              , fingerprint: key.fingerprint
+            , fingerprint: key.fingerprint
             }
-            , users: users
+          , users: users
           }
         })
     })
@@ -450,7 +450,7 @@ function addAdbPublicKey(req, res) {
       log.error('Failed to insert new adb key fingerprint: ', err.stack)
       return res.status(500).json({
         success: false
-        , message: 'Unable to insert new adb key fingerprint to database'
+      , message: 'Unable to insert new adb key fingerprint to database'
       })
     })
 }

--- a/lib/units/api/index.js
+++ b/lib/units/api/index.js
@@ -4,6 +4,7 @@ var events = require('events')
 
 var express = require('express')
 var SwaggerExpress = require('swagger-express-mw')
+var SwaggerUi = require('swagger-tools/middleware/swagger-ui');
 var cookieSession = require('cookie-session')
 var Promise = require('bluebird')
 var _ = require('lodash')
@@ -71,6 +72,7 @@ module.exports = function(options) {
     if (err) {
       throw err
     }
+    app.use(SwaggerUi(swaggerExpress.runner.swagger));
     swaggerExpress.register(app)
   })
 

--- a/lib/units/api/index.js
+++ b/lib/units/api/index.js
@@ -4,7 +4,7 @@ var events = require('events')
 
 var express = require('express')
 var SwaggerExpress = require('swagger-express-mw')
-var SwaggerUi = require('swagger-tools/middleware/swagger-ui');
+var SwaggerUi = require('swagger-tools/middleware/swagger-ui')
 var cookieSession = require('cookie-session')
 var Promise = require('bluebird')
 var _ = require('lodash')

--- a/lib/units/api/index.js
+++ b/lib/units/api/index.js
@@ -3,8 +3,8 @@ var path = require('path')
 var events = require('events')
 
 var express = require('express')
-var SwaggerExpress = require('swagger-express-mw')
-var SwaggerUi = require('swagger-tools/middleware/swagger-ui')
+var swaggerExpress = require('swagger-express-mw')
+var swaggerUi = require('swagger-tools/middleware/swagger-ui')
 var cookieSession = require('cookie-session')
 var Promise = require('bluebird')
 var _ = require('lodash')
@@ -68,11 +68,11 @@ module.exports = function(options) {
   , swaggerFile: path.resolve(__dirname, 'swagger', 'api_v1.yaml')
   }
 
-  SwaggerExpress.create(config, function(err, swaggerExpress) {
+  swaggerExpress.create(config, function(err, swaggerExpress) {
     if (err) {
       throw err
     }
-    app.use(SwaggerUi(swaggerExpress.runner.swagger));
+    app.use(swaggerUi(swaggerExpress.runner.swagger))
     swaggerExpress.register(app)
   })
 

--- a/lib/units/api/swagger/api_v1.yaml
+++ b/lib/units/api/swagger/api_v1.yaml
@@ -208,6 +208,41 @@ paths:
             $ref: "#/definitions/ErrorResponse"
       security:
         - accessTokenAuth: []
+  /user/adbPublicKeys:
+    x-swagger-router-controller: user
+    post:
+      summary: Adb public keys
+      description: Add adb public key for current user
+      operationId: addAdbPublicKey
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      tags:
+        - user
+      parameters:
+      - name: adb
+        in: body
+        schema:
+            type: object
+            required:
+              - publickey
+            properties:
+              publickey:
+                type: string
+                description: adb public key (~/.android/id_rsa.pub)
+              title:
+                type: string
+                description: By default will be extracted from public key
+      responses:
+        "200":
+          description: Add adb key response
+        default:
+          description: Unexpected Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+      security:
+        - accessTokenAuth: []
   /devices:
     x-swagger-router-controller: devices
     get:

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "stf-syrup": "^1.0.0",
     "stf-wiki": "^1.0.0",
     "swagger-express-mw": "^0.7.0",
+    "swagger-tools": "^0.10.3",
     "temp": "^0.8.1",
     "transliteration": "^1.1.6",
     "url-join": "1.1.0",


### PR DESCRIPTION
Reason: manually approve adb connection from web UI does not scale for test automation. Especially those that are using different adb keys on each session (eg: via container)

This changes also added swagger doc endpoint. Using `stf local` command, it will end up at: `http://localhost:7106/docs/`