### PR TITLE
Add OpenGL ES version to device properties.

### DIFF
--- a/lib/db/api.js
+++ b/lib/db/api.js
@@ -323,6 +323,7 @@ dbapi.saveDeviceIdentity = function(serial, identity) {
   , phone: identity.phone
   , product: identity.product
   , cpuPlatform: identity.cpuPlatform
+  , openGLESVersion: identity.openGLESVersion
   }))
 }
 

--- a/lib/units/device/plugins/solo.js
+++ b/lib/units/device/plugins/solo.js
@@ -43,6 +43,7 @@ module.exports = syrup.serial()
         , new wire.DevicePhoneMessage(identity.phone)
         , identity.product
         , identity.cpuPlatform
+        , identity.openGLESVersion
         ))
       ])
     })

--- a/lib/util/devutil.js
+++ b/lib/util/devutil.js
@@ -108,6 +108,17 @@ devutil.makeIdentity = function(serial, properties) {
   var abi = properties['ro.product.cpu.abi']
   var product = properties['ro.product.name']
   var cpuPlatform = properties['ro.board.platform']
+  var openGLESVersion = properties['ro.opengles.version']
+
+  openGLESVersion = parseInt(openGLESVersion, 10)
+  if (isNaN(openGLESVersion)) {
+    openGLESVersion = '0.0'
+  }
+  else {
+    var openGLESVersionMajor = (openGLESVersion & 0xffff0000) >> 16
+    var openGLESVersionMinor = (openGLESVersion & 0xffff)
+    openGLESVersion = openGLESVersionMajor + '.' + openGLESVersionMinor
+  }
 
   // Remove brand prefix for consistency
   if (model.substr(0, brand.length) === brand) {
@@ -132,5 +143,6 @@ devutil.makeIdentity = function(serial, properties) {
   , sdk: sdk
   , product: product
   , cpuPlatform: cpuPlatform
+  , openGLESVersion: openGLESVersion
   }
 }

--- a/lib/wire/wire.proto
+++ b/lib/wire/wire.proto
@@ -227,6 +227,7 @@ message DeviceIdentityMessage {
   required DevicePhoneMessage phone = 11;
   optional string product = 12;
   optional string cpuPlatform = 13;
+  optional string openGLESVersion = 14;
 }
 
 message DeviceProperty {

--- a/res/app/device-list/column/device-column-service.js
+++ b/res/app/device-list/column/device-column-service.js
@@ -201,6 +201,12 @@ module.exports = function DeviceColumnService($filter, gettext) {
         return device.cpuPlatform || ''
       }
     })
+  , openGLESVersion: TextCell({
+      title: gettext('OpenGL ES version')
+    , value: function(device) {
+        return device.openGLESVersion || ''
+      }
+    })
   , phone: TextCell({
       title: gettext('Phone')
     , value: function(device) {

--- a/res/app/device-list/device-list-controller.js
+++ b/res/app/device-list/device-list-controller.js
@@ -68,6 +68,10 @@ module.exports = function DeviceListCtrl(
     , selected: false
     }
   , {
+      name: 'openGLESVersion'
+    , selected: false
+    }
+  , {
       name: 'browser'
     , selected: false
     }


### PR DESCRIPTION
Sometimes apps requires a device having some minimal OpenGL ES version. This PR adds corresponding column in device list and field in API.

Version is always in format: `<major>.<minor>`. If undefined it falls back to `0.0` to be consistent with [GL_ES_VERSION_UNDEFINED](https://developer.android.com/reference/android/content/pm/FeatureInfo.html#GL_ES_VERSION_UNDEFINED) and to be always parsable as a float.