### PR TITLE
Filter out the WARNING info of minicap in order to adapt OPPO devices

### DIFF
--- a/lib/units/device/plugins/util/display.js
+++ b/lib/units/device/plugins/util/display.js
@@ -37,10 +37,11 @@ module.exports = syrup.serial()
           }
 
           try {
+            out = out.toString().replace(/WARNING:.*/g, "")
             return JSON.parse(out)
           }
           catch (e) {
-            throw new Error(out.toString())
+            throw new Error(e + out.toString())
           }
         })
     }

--- a/lib/units/device/plugins/util/display.js
+++ b/lib/units/device/plugins/util/display.js
@@ -37,8 +37,8 @@ module.exports = syrup.serial()
           }
 
           try {
-            out = out.toString().replace(/WARNING:.*/g, "")
-            return JSON.parse(out)
+            var displayInfo = out.toString().replace(/WARNING:.*/g, '')
+            return JSON.parse(displayInfo)
           }
           catch (e) {
             throw new Error(e + out.toString())


### PR DESCRIPTION
After upgrade minicap to 2.x, we encounter error below when connect with OPPO devices of Android SDK 22:

```
 2017-12-20T15:52:32.460Z FTL/device 24742 [e3a111b2] Setup had an error Error:
WARNING: linker: /data/local/tmp/minicap: unused DT entry: type 0x6fffffff arg 0x2
{
    "id": 0,
    "width": 1080,
    "height": 1920,
    "xdpi": 370.70,
    "ydpi": 369.45,
    "size": 5.96,
    "density": 3.00,
    "fps": 60.00,
    "secure": true,
    "rotation": 0
}
    
at /Users/hy/work/stf/lib/units/device/plugins/util/display.js:43:19
    at tryCatcher ….
```

So I added a line of  `out = out.toString().replace(/WARNING:.*/g, "")` to filter out WARNING info of minicap to make JSON parser happy.