### PR TITLE
Use 'ps -lef' instead of 'ps' to list Pids on Android 8.x

### DIFF
--- a/lib/units/device/plugins/screen/stream.js
+++ b/lib/units/device/plugins/screen/stream.js
@@ -375,7 +375,7 @@ module.exports = syrup.serial()
       }
 
       function kindKill() {
-        return kill('SIGTERM'
+        return kill('SIGTERM')
       }
 
       function forceKill() {

--- a/lib/units/device/plugins/screen/stream.js
+++ b/lib/units/device/plugins/screen/stream.js
@@ -375,7 +375,7 @@ module.exports = syrup.serial()
       }
 
       function kindKill() {
-        return kill('SIGTERM')
+        return kill('SIGTERM'
       }
 
       function forceKill() {

--- a/lib/util/devutil.js
+++ b/lib/util/devutil.js
@@ -44,27 +44,29 @@ devutil.listPidsByComm = function(adb, serial, comm, bin) {
   return new Promise(function(resolve) {
     if ('ps' in commands) {
       resolve(commands)
-    } else {
+    }
+    else {
       adb.getProperties(serial)
-        .then(function (properties) {
-          version = properties['ro.build.version.release']
-          if (version.match(/^8\./) != null) {
-            commands['ps'] = 'ps -lef'
-          } else {
-            commands['ps'] = 'ps'
+        .then(function(properties) {
+          var version = properties['ro.build.version.release']
+          if (version.match(/^8\./) !== null) {
+            commands["ps"] = 'ps -lef'
+          }
+          else {
+            commands["ps"] = 'ps'
           }
           resolve(commands)
         })
     }
   })
-  .then(function (commands) {
-     return  adb.shell(serial, [commands['ps']])
-            .then(function (out) {
-              return new Promise(function (resolve) {
+  .then(function(commands) {
+     return adb.shell(serial, [commands["ps"]])
+            .then(function(out) {
+              return new Promise(function(resolve) {
                 var header = true
                 var pids = []
                 out.pipe(split())
-                  .on('data', function (chunk) {
+                  .on('data', function(chunk) {
                     if (header) {
                       header = false
                     }
@@ -75,7 +77,7 @@ devutil.listPidsByComm = function(adb, serial, comm, bin) {
                       }
                     }
                   })
-                  .on('end', function () {
+                  .on('end', function() {
                     resolve(pids)
                   })
               })

--- a/lib/util/devutil.js
+++ b/lib/util/devutil.js
@@ -50,17 +50,17 @@ devutil.listPidsByComm = function(adb, serial, comm, bin) {
         .then(function(properties) {
           var version = properties['ro.build.version.release']
           if (version.match(/^8\./) !== null) {
-            commands["ps"] = 'ps -lef'
+            commands.ps = 'ps -lef'
           }
           else {
-            commands["ps"] = 'ps'
+            commands.ps = 'ps'
           }
           resolve(commands)
         })
     }
   })
   .then(function(commands) {
-     return adb.shell(serial, [commands["ps"]])
+     return adb.shell(serial, [commands.ps])
             .then(function(out) {
               return new Promise(function(resolve) {
                 var header = true

--- a/lib/util/devutil.js
+++ b/lib/util/devutil.js
@@ -5,8 +5,6 @@ var Promise = require('bluebird')
 
 var devutil = module.exports = Object.create(null)
 
-var commands = Object.create(null)
-
 function closedError(err) {
   return err.message.indexOf('closed') !== -1
 }
@@ -41,48 +39,28 @@ devutil.listPidsByComm = function(adb, serial, comm, bin) {
     shell: true
   }
 
-  return new Promise(function(resolve) {
-    if ('ps' in commands) {
-      resolve(commands)
-    }
-    else {
-      adb.getProperties(serial)
-        .then(function(properties) {
-          var version = properties['ro.build.version.release']
-          if (version.match(/^8\./) !== null) {
-            commands.ps = 'ps -lef'
-          }
-          else {
-            commands.ps = 'ps'
-          }
-          resolve(commands)
-        })
-    }
-  })
-  .then(function(commands) {
-     return adb.shell(serial, [commands.ps])
-            .then(function(out) {
-              return new Promise(function(resolve) {
-                var header = true
-                var pids = []
-                out.pipe(split())
-                  .on('data', function(chunk) {
-                    if (header) {
-                      header = false
+  return adb.shell(serial, 'ps -lef||ps')
+         .then(function(out) {
+            return new Promise(function(resolve) {
+              var header = true
+              var pids = []
+              out.pipe(split())
+                .on('data', function(chunk) {
+                  if (header&&chunk.toString().indexOf('bad pid') === -1) {
+                    header = false
+                  }
+                  else {
+                    var cols = chunk.toString().split(/\s+/)
+                    if (cols.pop() === bin && users[cols[0]]) {
+                      pids.push(Number(cols[1]))
                     }
-                    else {
-                      var cols = chunk.toString().split(/\s+/)
-                      if (cols.pop() === bin && users[cols[0]]) {
-                        pids.push(Number(cols[1]))
-                      }
-                    }
-                  })
-                  .on('end', function() {
-                    resolve(pids)
-                  })
-              })
+                  }
+                })
+                .on('end', function() {
+                  resolve(pids)
+                })
             })
-  })
+         })
 }
 
 devutil.waitForProcsToDie = function(adb, serial, comm, bin) {

--- a/lib/util/devutil.js
+++ b/lib/util/devutil.js
@@ -43,6 +43,8 @@ devutil.listPidsByComm = function(adb, serial, comm, bin) {
     return new Promise(function(resolve) {
       var header = true
       var pids = []
+      var showTotalPid = false
+
       out.pipe(split())
         .on('data', function(chunk) {
           if (header) {
@@ -50,26 +52,39 @@ devutil.listPidsByComm = function(adb, serial, comm, bin) {
           }
           else {
             var cols = chunk.toString().split(/\s+/)
-            if (cols.pop() === comm && users[cols[0]]) {
+            if (!showTotalPid && cols[0] === 'root') {
+              showTotalPid = true
+            }
+
+            // last column of output would be command name containing absolute path like '/data/local/tmp/minicap'
+            // or just binary name like 'minicap', it depends on device/ROM
+            var lastCol = cols.pop()
+            if ((lastCol === comm || lastCol === bin) && users[cols[0]]) {
               pids.push(Number(cols[1]))
             }
           }
         })
         .on('end', function() {
-          resolve(pids)
+          resolve({showTotalPid: showTotalPid, pids: pids})
         })
     })
   }
 
   return adb.shell(serial, 'ps 2>/dev/null')
      .then(findProcess)
-     .then(function(pids) {
-       if (pids.length > 0) { // return pids if process can be found in the output of 'ps' command
-         return Promise.resolve(pids)
+     .then(function(res) {
+       // return pids if process can be found in the output of 'ps' command
+       // or 'ps' command has already displayed all the processes including processes launched by root user
+       if (res.showTotalPid || res.pids.length > 0) {
+         return Promise.resolve(res.pids)
        }
-       else {                 // otherwise try to run 'ps -elf'
+       // otherwise try to run 'ps -elf'
+       else {
          return adb.shell(serial, 'ps -lef 2>/dev/null')
            .then(findProcess)
+           .then(function(res) {
+              return Promise.resolve(res.pids)
+           })
        }
      })
 }

--- a/lib/util/devutil.js
+++ b/lib/util/devutil.js
@@ -39,28 +39,39 @@ devutil.listPidsByComm = function(adb, serial, comm, bin) {
     shell: true
   }
 
-  return adb.shell(serial, 'ps -lef||ps')
-         .then(function(out) {
-            return new Promise(function(resolve) {
-              var header = true
-              var pids = []
-              out.pipe(split())
-                .on('data', function(chunk) {
-                  if (header && chunk.toString().indexOf('bad pid') === -1) {
-                    header = false
-                  }
-                  else {
-                    var cols = chunk.toString().split(/\s+/)
-                    if (cols.pop() === bin && users[cols[0]]) {
-                      pids.push(Number(cols[1]))
-                    }
-                  }
-                })
-                .on('end', function() {
-                  resolve(pids)
-                })
-            })
-         })
+  var findProcess = function(out) {
+    return new Promise(function(resolve) {
+      var header = true
+      var pids = []
+      out.pipe(split())
+        .on('data', function(chunk) {
+          if (header) {
+            header = false
+          }
+          else {
+            var cols = chunk.toString().split(/\s+/)
+            if (cols.pop() === bin && users[cols[0]]) {
+              pids.push(Number(cols[1]))
+            }
+          }
+        })
+        .on('end', function() {
+          resolve(pids)
+        })
+    })
+  }
+
+  return adb.shell(serial, 'ps')
+     .then(findProcess)
+     .then(function(pids) {
+       if (pids.length > 0) { // return pids if process can be found in the output of 'ps' command
+         return Promise.resolve(pids)
+       }
+       else {                 // otherwise try to run 'ps -elf'
+         return adb.shell(serial, 'ps -lef')
+           .then(findProcess)
+       }
+     })
 }
 
 devutil.waitForProcsToDie = function(adb, serial, comm, bin) {

--- a/lib/util/devutil.js
+++ b/lib/util/devutil.js
@@ -5,6 +5,8 @@ var Promise = require('bluebird')
 
 var devutil = module.exports = Object.create(null)
 
+var commands = Object.create(null)
+
 function closedError(err) {
   return err.message.indexOf('closed') !== -1
 }
@@ -39,28 +41,46 @@ devutil.listPidsByComm = function(adb, serial, comm, bin) {
     shell: true
   }
 
-  return adb.shell(serial, ['ps'])
-    .then(function(out) {
-      return new Promise(function(resolve) {
-        var header = true
-        var pids = []
-        out.pipe(split())
-          .on('data', function(chunk) {
-            if (header) {
-              header = false
-            }
-            else {
-              var cols = chunk.toString().split(/\s+/)
-              if (cols.pop() === bin && users[cols[0]]) {
-                pids.push(Number(cols[1]))
-              }
-            }
-          })
-          .on('end', function() {
-            resolve(pids)
-          })
-      })
-    })
+  return new Promise(function(resolve) {
+    if ('ps' in commands) {
+      resolve(commands)
+    } else {
+      adb.getProperties(serial)
+        .then(function (properties) {
+          version = properties['ro.build.version.release']
+          if (version.match(/^8\./) != null) {
+            commands['ps'] = 'ps -lef'
+          } else {
+            commands['ps'] = 'ps'
+          }
+          resolve(commands)
+        })
+    }
+  })
+  .then(function (commands) {
+     return  adb.shell(serial, [commands['ps']])
+            .then(function (out) {
+              return new Promise(function (resolve) {
+                var header = true
+                var pids = []
+                out.pipe(split())
+                  .on('data', function (chunk) {
+                    if (header) {
+                      header = false
+                    }
+                    else {
+                      var cols = chunk.toString().split(/\s+/)
+                      if (cols.pop() === bin && users[cols[0]]) {
+                        pids.push(Number(cols[1]))
+                      }
+                    }
+                  })
+                  .on('end', function () {
+                    resolve(pids)
+                  })
+              })
+            })
+  })
 }
 
 devutil.waitForProcsToDie = function(adb, serial, comm, bin) {

--- a/lib/util/devutil.js
+++ b/lib/util/devutil.js
@@ -50,7 +50,7 @@ devutil.listPidsByComm = function(adb, serial, comm, bin) {
           }
           else {
             var cols = chunk.toString().split(/\s+/)
-            if (cols.pop() === bin && users[cols[0]]) {
+            if (cols.pop() === comm && users[cols[0]]) {
               pids.push(Number(cols[1]))
             }
           }
@@ -61,14 +61,14 @@ devutil.listPidsByComm = function(adb, serial, comm, bin) {
     })
   }
 
-  return adb.shell(serial, 'ps')
+  return adb.shell(serial, 'ps 2>/dev/null')
      .then(findProcess)
      .then(function(pids) {
        if (pids.length > 0) { // return pids if process can be found in the output of 'ps' command
          return Promise.resolve(pids)
        }
        else {                 // otherwise try to run 'ps -elf'
-         return adb.shell(serial, 'ps -lef')
+         return adb.shell(serial, 'ps -lef 2>/dev/null')
            .then(findProcess)
        }
      })

--- a/lib/util/devutil.js
+++ b/lib/util/devutil.js
@@ -46,7 +46,7 @@ devutil.listPidsByComm = function(adb, serial, comm, bin) {
               var pids = []
               out.pipe(split())
                 .on('data', function(chunk) {
-                  if (header&&chunk.toString().indexOf('bad pid') === -1) {
+                  if (header && chunk.toString().indexOf('bad pid') === -1) {
                     header = false
                   }
                   else {


### PR DESCRIPTION
Since Android 8.0 official version, 'ps' command is not workable to list process list. We should use 'ps -lef' instead on Android 8.0 and Android 8.1, so I attempt to fix the problem in lib/util/devutil.js. 
