### PR TITLE
Add package whitelist  for auto-cleanup function

### DIFF
--- a/lib/cli/device/index.js
+++ b/lib/cli/device/index.js
@@ -25,6 +25,11 @@ module.exports.builder = function(yargs) {
     , type: 'boolean'
     , default: true
     })
+    .option('cleanup-white-list', {
+      describe: 'White list of package name which would not be uninstalled between uses'
+    , array: true
+    , default: []
+    })
     .option('connect-port', {
       describe: 'Port allocated to adb connections.'
     , type: 'number'
@@ -165,5 +170,6 @@ module.exports.handler = function(argv) {
   , muteMaster: argv.muteMaster
   , lockRotation: argv.lockRotation
   , cleanup: argv.cleanup
+  , cleanupWhiteList: argv.cleanupWhiteList
   })
 }

--- a/lib/cli/provider/index.js
+++ b/lib/cli/provider/index.js
@@ -34,10 +34,16 @@ module.exports.builder = function(yargs) {
     })
     .option('cleanup', {
       describe: 'Attempt to reset the device between uses by uninstalling' +
-        'apps, resetting accounts and clearing caches. Does not do a perfect ' +
-        'job currently. Negate with --no-cleanup.'
+      'apps, resetting accounts and clearing caches. Does not do a perfect ' +
+      'job currently. Negate with --no-cleanup.'
     , type: 'boolean'
     , default: true
+    })
+    .option('white-list-file', {
+      describe: 'The white list file used to specify packages which will not be ' +
+      'uninstalled between uses.'
+    , type: 'string'
+    , default: './cleanup-white-list.conf'
     })
     .option('connect-push', {
       alias: 'p'
@@ -167,7 +173,7 @@ module.exports.handler = function(argv) {
       return argv.serial.length === 0 || argv.serial.indexOf(device.id) !== -1
     }
   , allowRemote: argv.allowRemote
-  , fork: function(device, ports) {
+  , fork: function(device, ports, whiteList) {
       var fork = require('child_process').fork
 
       var args = [
@@ -199,6 +205,9 @@ module.exports.handler = function(argv) {
       }, []))
       .concat(argv.lockRotation ? ['--lock-rotation'] : [])
       .concat(!argv.cleanup ? ['--no-cleanup'] : [])
+      .concat(whiteList.reduce(function(all, val) {
+        return all.concat(['--cleanup-white-list', val])
+      }, []))
 
       return fork(cli, args)
     }
@@ -208,5 +217,6 @@ module.exports.handler = function(argv) {
     }
   , adbHost: argv.adbHost
   , adbPort: argv.adbPort
+  , whiteListFile: argv.whiteListFile
   })
 }

--- a/lib/units/device/plugins/cleanup.js
+++ b/lib/units/device/plugins/cleanup.js
@@ -37,6 +37,7 @@ module.exports = syrup.serial()
           return listPackages()
             .then(function(currentPackages) {
               var remove = _.difference(currentPackages, initialPackages)
+              remove = _.difference(remove, options.cleanupWhiteList)
               return Promise.map(remove, uninstallPackage)
             })
         }

--- a/lib/units/provider/index.js
+++ b/lib/units/provider/index.js
@@ -2,6 +2,7 @@ var adb = require('adbkit')
 var Promise = require('bluebird')
 var _ = require('lodash')
 var EventEmitter = require('eventemitter3')
+var fs = require('fs')
 
 var logger = require('../../util/logger')
 var wire = require('../../wire')
@@ -107,6 +108,24 @@ module.exports = function(options) {
     sub.subscribe(channel)
   })
 
+  // Read white list file for package cleanup between uses
+  var whiteList = function() {
+    var whiteListFile = options.whiteListFile
+    if (fs.existsSync(whiteListFile) === false) {
+      log.warn("White list file %s doesn't exist", whiteListFile)
+      return []
+    }
+
+    var whiteList = fs.readFileSync(whiteListFile)
+                      .toString()
+                      .split('\n')
+                      .map(s => s.trim())
+                      .filter(Boolean)    // remove empty elements
+    whiteList = _.uniq(whiteList)         // remove duplicate elements
+
+    return whiteList
+  }()
+
   // Track and manage devices
   client.trackDevices().then(function(tracker) {
     log.info('Tracking devices')
@@ -175,11 +194,11 @@ module.exports = function(options) {
         privateTracker.once('register', resolve)
       })
 
-
       // Spawn a device worker
       function spawn() {
         var allocatedPorts = ports.splice(0, 4)
-        var proc = options.fork(device, allocatedPorts.slice())
+        var proc = options.fork(device, allocatedPorts.slice(), whiteList)
+
         var resolver = Promise.defer()
         var didExit = false
 


### PR DESCRIPTION
Add an option '--white-list-file' in provider. The packages specified in white list file will not be auto-cleanup between uses. 