### PR TITLE
Fix formidable's new default maximum file size.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fixed a setup issue with TPS650.
+- Fixed an issue where most uploads would fail due to a breaking configuration change in a dependency.
 
 ## 3.2.0 (2017-12-06)
 

--- a/lib/cli/storage-s3/index.js
+++ b/lib/cli/storage-s3/index.js
@@ -16,6 +16,12 @@ module.exports.builder = function(yargs) {
     , type: 'string'
     , demand: true
     })
+    .option('max-file-size', {
+      describe: 'Maximum file size to allow for uploads. Note that nginx ' +
+        'may have a separate limit, meaning you should change both.'
+    , type: 'number'
+    , default: 1 * 1024 * 1024 * 1024
+    })
     .option('port', {
       alias: 'p'
     , describe: 'The port to bind to.'
@@ -39,5 +45,6 @@ module.exports.handler = function(argv) {
   , profile: argv.profile
   , bucket: argv.bucket
   , endpoint: argv.endpoint
+  , maxFileSize: argv.maxFileSize
   })
 }

--- a/lib/cli/storage-temp/index.js
+++ b/lib/cli/storage-temp/index.js
@@ -8,6 +8,12 @@ module.exports.builder = function(yargs) {
   return yargs
     .env('STF_STORAGE_TEMP')
     .strict()
+    .option('max-file-size', {
+      describe: 'Maximum file size to allow for uploads. Note that nginx ' +
+        'may have a separate limit, meaning you should change both.'
+    , type: 'number'
+    , default: 1 * 1024 * 1024 * 1024
+    })
     .option('port', {
       alias: 'p'
     , describe: 'The port to bind to.'
@@ -29,5 +35,6 @@ module.exports.handler = function(argv) {
   return require('../../units/storage/temp')({
     port: argv.port
   , saveDir: argv.saveDir
+  , maxFileSize: argv.maxFileSize
   })
 }

--- a/lib/units/storage/s3.js
+++ b/lib/units/storage/s3.js
@@ -72,7 +72,9 @@ module.exports = function(options) {
   }
 
   app.post('/s/upload/:plugin', function(req, res) {
-    var form = new formidable.IncomingForm()
+    var form = new formidable.IncomingForm({
+      maxFileSize: options.maxFileSize
+    })
     var plugin = req.params.plugin
     Promise.promisify(form.parse, form)(req)
       .spread(function(fields, files) {

--- a/lib/units/storage/temp.js
+++ b/lib/units/storage/temp.js
@@ -83,7 +83,9 @@ module.exports = function(options) {
   })
 
   app.post('/s/upload/:plugin', function(req, res) {
-    var form = new formidable.IncomingForm()
+    var form = new formidable.IncomingForm({
+      maxFileSize: options.maxFileSize
+    })
     if (options.saveDir) {
       form.uploadDir = options.saveDir
     }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eventemitter3": "^1.2.0",
     "express": "^4.14.0",
     "express-validator": "^2.20.8",
-    "formidable": "^1.0.17",
+    "formidable": "^1.2.0",
     "gm": "^1.23.0",
     "hipchatter": "^0.3.1",
     "http-proxy": "^1.11.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2429,9 +2429,13 @@ formatio@1.1.1:
   dependencies:
     samsam "~1.1"
 
-formidable@^1.0.17, formidable@^1.1.1:
+formidable@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.1.1.tgz#96b8886f7c3c3508b932d6bd70c4d3a88f35f1a9"
+
+formidable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.0.tgz#ce291bfec67c176e282f891ece2c37de0c83ae84"
 
 forwarded@~0.1.0:
   version "0.1.0"


### PR DESCRIPTION
As per #826, the newest version of formidable [changes](https://github.com/felixge/node-formidable/commit/b81d1c71cd3774419571c360db4312c965a57a13) the default maximum file size to 2MB, which is way too low for anything. Make the limit configurable and set to 1GB by default.