### PR TITLE
Support new connecting and authorizing device states from ADB

### DIFF
--- a/lib/wire/util.js
+++ b/lib/wire/util.js
@@ -13,6 +13,8 @@ var wireutil = {
     , emulator: 'ONLINE'
     , unauthorized: 'UNAUTHORIZED'
     , offline: 'OFFLINE'
+    , connecting: 'CONNECTING'
+    , authorizing: 'AUTHORIZING'
     }[type]]
   }
 , toDeviceRequirements: function(requirements) {

--- a/lib/wire/wire.proto
+++ b/lib/wire/wire.proto
@@ -171,6 +171,8 @@ enum DeviceStatus {
   OFFLINE = 1;
   UNAUTHORIZED = 2;
   ONLINE = 3;
+  CONNECTING = 4;
+  AUTHORIZING = 5;
 }
 
 message DeviceStatusMessage {


### PR DESCRIPTION
The latest version of ADB introduced 2 new device status: connecting and authorizing

See https://github.com/aosp-mirror/platform_system_core/commit/704494b0707a49e064b63192619a73336c1be05a

Without these states, devices sometimes have a problem getting registered with STF.  The error that's encountered is something along the lines of:

```
Jul 13 15:00:36 stf run.sh[2109]: Unhandled rejection Error: Illegal value for Message.Field .DeviceIntroductionMessage.status of type enum: undefined (not a valid enum value)
Jul 13 15:00:36 stf run.sh[2109]:     at Field.<anonymous> (/home/tapjoy/.nvm/versions/node/v7.8.0/lib/node_modules/stf/node_modules/protobufjs/dist/ProtoBuf.js:2641:27)
Jul 13 15:00:36 stf run.sh[2109]:     at Field.ProtoBuf.Reflect.FieldPrototype.verifyValue (/home/tapjoy/.nvm/versions/node/v7.8.0/lib/node_modules/stf/node_modules/protobufjs/dist/ProtoBuf.js:2738:25)
Jul 13 15:00:36 stf run.sh[2109]:     at MessagePrototype.set (/home/tapjoy/.nvm/versions/node/v7.8.0/lib/node_modules/stf/node_modules/protobufjs/dist/ProtoBuf.js:1799:63)
Jul 13 15:00:36 stf run.sh[2109]:     at Message (/home/tapjoy/.nvm/versions/node/v7.8.0/lib/node_modules/stf/node_modules/protobufjs/dist/ProtoBuf.js:1728:42)
Jul 13 15:00:36 stf run.sh[2109]:     at /home/tapjoy/.nvm/versions/node/v7.8.0/lib/node_modules/stf/lib/units/provider/index.js:165:29
Jul 13 15:00:36 stf run.sh[2109]:     at /home/tapjoy/.nvm/versions/node/v7.8.0/lib/node_modules/stf/lib/units/provider/index.js:161:22
Jul 13 15:00:36 stf run.sh[2109]:     at Tracker.<anonymous> (/home/tapjoy/.nvm/versions/node/v7.8.0/lib/node_modules/stf/lib/units/provider/index.js:144:16)
Jul 13 15:00:36 stf run.sh[2109]:     at emitOne (events.js:96:13)
Jul 13 15:00:36 stf run.sh[2109]:     at Tracker.emit (events.js:191:7)
Jul 13 15:00:36 stf run.sh[2109]:     at Tracker.update (/home/tapjoy/.nvm/versions/node/v7.8.0/lib/node_modules/stf/node_modules/adbkit/lib/adb/tracker.js:62:14)
Jul 13 15:00:36 stf run.sh[2109]:     at /home/tapjoy/.nvm/versions/node/v7.8.0/lib/node_modules/stf/node_modules/adbkit/lib/adb/tracker.js:38:15
Jul 13 15:00:36 stf run.sh[2109]:     at runCallback (timers.js:672:20)
```

If you look at the device status, you'll see

```
Jul 13 15:00:35 stf run.sh[2109]: 2018-07-13T19:00:35.994Z INF/provider 2321 [*] Found device "..." (connecting)
```

I was able to verify after making this change that my phones would get properly registered and no errors were shown when unplugging / plugging back in.

This fixes #907.