### PR TITLE
删除字体模块

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,6 @@
     "angular-growl-v2": "JanStevens/angular-growl-2#~0.7.9",
     "underscore.string": "~3.2.3",
     "bootstrap": "~3.3.6",
-    "font-lato-2-subset": "~0.4.0",
     "packery": "~1.4.3",
     "draggabilly": "~1.2.4",
     "angular-elastic": "~2.5.1",

--- a/res/web_modules/nine-bootstrap/index.js
+++ b/res/web_modules/nine-bootstrap/index.js
@@ -3,5 +3,3 @@ require('bootstrap/dist/css/bootstrap.css')
 require('nine-bootstrap/nine-bootstrap.scss')
 
 require('components-font-awesome/css/font-awesome.css')
-
-require('font-lato-2-subset')


### PR DESCRIPTION
当远程访问时，很多系统因为缺少Lato字体导致浏览效果不友好，建议删除该模块