### PR TITLE
Fix for stdout race condition in stf doctor

### DIFF
--- a/lib/cli/doctor/index.js
+++ b/lib/cli/doctor/index.js
@@ -30,16 +30,13 @@ module.exports.handler = function() {
       var proc = cp.spawn(command, args, options)
       var stdout = []
 
-      proc.stdout.on('readable', function() {
-        var chunk
-        while ((chunk = proc.stdout.read())) {
-          stdout.push(chunk)
-        }
+      proc.stdout.on('data', function(data) {
+        stdout.push(data)
       })
 
       proc.on('error', reject)
 
-      proc.on('exit', function(code, signal) {
+      proc.on('close', function(code, signal) {
         if (signal) {
           reject(new CheckError('Exited with signal %s', signal))
         }


### PR DESCRIPTION
Sometimes the process exits before the data is read from stdout. The result is that the `call` method exits before it has it's output.

Example bug: https://github.com/openstf/stf/issues/1091