### PR TITLE
Catch a touchMove error

### DIFF
--- a/lib/units/websocket/index.js
+++ b/lib/units/websocket/index.js
@@ -548,16 +548,21 @@ module.exports = function(options) {
           ])
         })
         .on('input.touchMove', function(channel, data) {
-          push.send([
-            channel
-          , wireutil.envelope(new wire.TouchMoveMessage(
-              data.seq
-            , data.contact
-            , data.x
-            , data.y
-            , data.pressure
-            ))
-          ])
+          try {
+            push.send([
+              channel
+            , wireutil.envelope(new wire.TouchMoveMessage(
+                data.seq
+              , data.contact
+              , data.x
+              , data.y
+              , data.pressure
+              ))
+            ])
+          }
+          catch(err) {
+            log.error('input.touchMove had an error', err.stack)
+          }
         })
         .on('input.touchUp', function(channel, data) {
           push.send([

--- a/lib/units/websocket/index.js
+++ b/lib/units/websocket/index.js
@@ -561,6 +561,7 @@ module.exports = function(options) {
             ])
           }
           catch(err) {
+            //workaround for https://github.com/openstf/stf/issues/1180
             log.error('input.touchMove had an error', err.stack)
           }
         })


### PR DESCRIPTION
### Related issue

https://github.com/openstf/stf/issues/1180

### Overview

Multiple touch by using like MicroSoft Surface or Tablets causes a  touchMove error.
The error makes stf service down.
In order to avoid service down, catch the error.

```
/usr/lib/node_modules/stf/node_modules/protobufjs/dist/ProtoBuf.js:2641
                    throw Error("Illegal value for "+this.toString(true)+" of type "+this.type.name+": "+val+" ("+msg+")");
                    ^

Error: Illegal value for Message.Field .TouchMoveMessage.contact of type uint32: undefined (not an integer)
    at Field.<anonymous> (/usr/lib/node_modules/stf/node_modules/protobufjs/dist/ProtoBuf.js:2641:27)
    at Field.ProtoBuf.Reflect.FieldPrototype.verifyValue (/usr/lib/node_modules/stf/node_modules/protobufjs/dist/ProtoBuf.js:2675:29)
    at MessagePrototype.set (/usr/lib/node_modules/stf/node_modules/protobufjs/dist/ProtoBuf.js:1799:63)
    at new Message (/usr/lib/node_modules/stf/node_modules/protobufjs/dist/ProtoBuf.js:1728:42)
    at Socket.<anonymous> (/usr/lib/node_modules/stf/lib/units/websocket/index.js:466:31)
    at emitTwo (events.js:126:13)
    at Socket.emit (events.js:214:7)
    at /usr/lib/node_modules/stf/node_modules/socket.io/lib/socket.js:528:12
    at _combinedTickCallback (internal/process/next_tick.js:132:7)
    at process._tickCallback (internal/process/next_tick.js:181:9)
```