### PR TITLE
[armhf] address npm 'could not get uid/gid' error when building with docker buildx for cross-compiling

### DIFF
--- a/Dockerfile-debian-armhf
+++ b/Dockerfile-debian-armhf
@@ -42,6 +42,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     cd /tmp/build && \
     export PATH=$PWD/node_modules/.bin:$PATH && \
     sed -i'' -e '/phantomjs/d' package.json && \
+    npm config set unsafe-perm true && \
     npm install -g npm && \
     echo 'npm cache clean --force' | su stf -s /bin/bash && \
     echo 'npm install --no-optional --loglevel http' | su stf -s /bin/bash && \


### PR DESCRIPTION
docker buildx tool would produce an error `Error: could not get uid/gid, [ 'nobody', 0 ]` when cross-compiling (I'm not sure if this happened on an actual arm device, I didn't try).

After adding this npm configuration, the build succeeds (after 40 minutes!).

The full error was:

```+ npm install -g npm
Unknown QEMU_IFLA_INFO_KIND ipip
Unknown QEMU_IFLA_INFO_KIND ip6tnl
Error: could not get uid/gid
[ 'nobody', 0 ]

    at /usr/local/lib/node_modules/npm/node_modules/uid-number/uid-number.js:37:16
    at ChildProcess.exithandler (child_process.js:280:5)
    at ChildProcess.emit (events.js:180:13)
    at maybeClose (internal/child_process.js:936:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:220:5)
TypeError: Cannot read property 'get' of undefined
    at errorHandler (/usr/local/lib/node_modules/npm/lib/utils/error-handler.js:205:18)
    at /usr/local/lib/node_modules/npm/bin/npm-cli.js:83:20
    at cb (/usr/local/lib/node_modules/npm/lib/npm.js:224:22)
    at /usr/local/lib/node_modules/npm/lib/npm.js:262:24
    at /usr/local/lib/node_modules/npm/lib/config/core.js:81:7
    at Array.forEach (<anonymous>)
    at /usr/local/lib/node_modules/npm/lib/config/core.js:80:13
    at f (/usr/local/lib/node_modules/npm/node_modules/once/once.js:25:25)
    at afterExtras (/usr/local/lib/node_modules/npm/lib/config/core.js:178:20)
    at Conf.<anonymous> (/usr/local/lib/node_modules/npm/lib/config/core.js:236:22)
    at /usr/local/lib/node_modules/npm/node_modules/uid-number/uid-number.js:39:14
    at ChildProcess.exithandler (child_process.js:280:5)
    at ChildProcess.emit (events.js:180:13)
    at maybeClose (internal/child_process.js:936:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:220:5)
/usr/local/lib/node_modules/npm/lib/utils/error-handler.js:205
  if (npm.config.get('json')) {
                 ^

TypeError: Cannot read property 'get' of undefined
    at process.errorHandler (/usr/local/lib/node_modules/npm/lib/utils/error-handler.js:205:18)
    at process.emit (events.js:180:13)
    at process._fatalException (bootstrap_node.js:431:27)```