### PR TITLE
Updates node-sass to v4.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "less-loader": "^2.2.2",
     "memory-fs": "^0.3.0",
     "node-libs-browser": "^1.0.0",
-    "node-sass": "^3.4.2",
+    "node-sass": "^4.13.1",
     "phantomjs-prebuilt": "^2.1.11",
     "protractor": "^5.4.1",
     "protractor-html-reporter-2": "1.0.4",


### PR DESCRIPTION
### Overview

STF requires Node.js v8.x.
But as you can see from the release note, node-sass v3.4.2 no longer provides the binary built for Node.js v8.x.
https://github.com/sass/node-sass/releases/tag/v3.4.2

```
21:16:10   Downloading binary from https://github.com/sass/node-sass/releases/download/v3.13.1/linux-x64-57_binding.node
21:16:11   Cannot download "https://github.com/sass/node-sass/releases/download/v3.13.1/linux-x64-57_binding.node": 
21:16:11  
21:16:11   HTTP error 404 Not Found
21:16:11  
21:16:11   Hint: If github.com is not accessible in your location
21:16:11         try setting a proxy via HTTP_PROXY, e.g. 
21:16:11  
21:16:11         export HTTP_PROXY=http://example.com:1234
21:16:11  
21:16:11   or configure npm proxy via
21:16:11  
21:16:11         npm config set proxy http://example.com:8080
```

So, I update node-sass to the latest version at present (v4.13.1).
This version supports Node.js 8.x.
https://github.com/sass/node-sass/releases/tag/v4.13.1


