### PR TITLE
Bump up 3.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stf",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Smartphone Test Farm",
   "keywords": [
     "adb",


### PR DESCRIPTION
### Overview

STF 3.4.2 has released.
https://github.com/openstf/stf/releases/tag/v3.4.2

So, I think the version in package.json should be bumped up.