### PR TITLE
Added Easy Installer (shellscipt) for Mac and Linux

### DIFF
--- a/Setup/Mac/Install.sh
+++ b/Setup/Mac/Install.sh
@@ -1,0 +1,30 @@
+# 
+# Copyright 2020 VMware, Inc
+# SPDX-License-Identifier:Apache2.0
+# 
+
+# ./Setup/Mac/Install.sh
+# Mac Installer
+
+# Homebrew
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+
+# adb tools
+brew cask install android-platform-tools
+
+# node & npm
+curl https://nodejs.org/dist/latest-v8.x/node-v8.17.0.pkg --output node-v8.17.0.pkg
+sudo installer -store -pkg "node-v8.17.0.pkg" -target /
+node -v
+
+# git
+brew install git
+
+# rethinkdb graphicsmagick zeromq protobuf yasm pkg-config
+brew install rethinkdb graphicsmagick zeromq protobuf yasm pkg-config
+
+# stf node module
+sudo npm install -g stf --unsafe-perm=true --allow-roots
+
+# health of requirements
+stf doctor

--- a/Setup/Mac/Master.sh
+++ b/Setup/Mac/Master.sh
@@ -1,0 +1,10 @@
+# 
+# Copyright 2020 VMware, Inc
+# SPDX-License-Identifier:Apache2.0
+# 
+
+# Mac Master Installer inside stf folder
+sudo npm install gulp-cli -g
+npm install
+sudo npm link # --unsafe-perm=true --allow-roots
+gulp clean

--- a/Setup/Mac/Provider.sh
+++ b/Setup/Mac/Provider.sh
@@ -1,0 +1,8 @@
+# 
+# Copyright 2020 VMware, Inc
+# SPDX-License-Identifier:Apache2.0
+# 
+
+
+# Ubuntu Run Provider Unit
+stf provider --connect-sub tcp://$1:7114 --connect-push tcp://$1:7116 --storage-url http://$1:7100 --name $2

--- a/Setup/Mac/Run.sh
+++ b/Setup/Mac/Run.sh
@@ -1,0 +1,7 @@
+# 
+# Copyright 2020 VMware, Inc
+# SPDX-License-Identifier:Apache2.0
+# 
+
+# Mac Run Master Server
+stf local --bind-dev-pub tcp://$1:7114 --bind-dev-pull tcp://$1:7116 --public-ip $1 --allow-remote

--- a/Setup/Ubuntu/Install.sh
+++ b/Setup/Ubuntu/Install.sh
@@ -1,0 +1,63 @@
+# 
+# Copyright 2020 VMware, Inc
+# SPDX-License-Identifier:Apache2.0
+# 
+
+# ./Setup/Ubuntu/Install.sh
+# Ubuntu Installer
+
+# Basic Req
+sudo apt-get install -y python-software-properties
+sudo add-apt-repository ppa:webupd8team/java
+sudo apt-get update
+sudo apt-get install -y oracle-java7-installer
+
+#adb
+sudo apt-get install -y lib32stdc++6
+
+#Set Vars
+export ANDROID_SDK="$HOME/android-sdk-linux"
+PATH=$PATH:$ANDROID_SDK/platform-tools;$ANDROID_SDK/tools
+
+
+##PREREQ
+#Node.js >= 0.12
+sudo apt-get install -y node.js
+
+
+#RethinkDB >= 2.2
+source /etc/lsb-release && echo "deb http://download.rethinkdb.com/apt $DISTRIB_CODENAME main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
+wget -qO- https://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
+sudo apt-get update
+sudo apt-get install -y rethinkdb
+
+#GraphicsMagick
+sudo apt-get install -y graphicsmagick
+
+#ZeroMQ [all versions taken care]
+sudo apt-get install -y libzmq1
+sudo apt-get install -y libzmq-dev
+sudo apt-get install -y libzmq3-dev
+
+#Protocol Buffers
+sudo apt-get install -y libprotobuf*
+sudo apt-get install -y protobuf-compiler
+
+#yasm
+sudo apt-get install -y yasm
+sudo apt-get install -y npm
+sudo apt-get install -y nodejs-legacy
+npm install -y --save jpeg-turbo
+
+#pkg-config
+sudo apt-get install -y pkg-config
+
+#adb
+sudo apt install -y adb
+
+##STF
+sudo apt-get install -y git
+sudo npm install -g stf
+
+# Check
+stf doctor

--- a/Setup/Ubuntu/Master.sh
+++ b/Setup/Ubuntu/Master.sh
@@ -1,0 +1,12 @@
+# 
+# Copyright 2020 VMware, Inc
+# SPDX-License-Identifier:Apache2.0
+# 
+
+
+# Ubuntu Master Installer inside stf folder
+sudo npm install gulp-cli -g
+npm install
+sudo npm link
+gulp clean
+

--- a/Setup/Ubuntu/Provider.sh
+++ b/Setup/Ubuntu/Provider.sh
@@ -1,0 +1,7 @@
+# 
+# Copyright 2020 VMware, Inc
+# SPDX-License-Identifier:Apache2.0
+# 
+
+# Ubuntu Run Provider Unit
+stf provider --connect-sub tcp://$1:7114 --connect-push tcp://$1:7116 --storage-url http://$1:7100 --name $2

--- a/Setup/Ubuntu/Run.sh
+++ b/Setup/Ubuntu/Run.sh
@@ -1,0 +1,7 @@
+# 
+# Copyright 2020 VMware, Inc
+# SPDX-License-Identifier:Apache2.0
+# 
+
+# Ubuntu Run Master Server
+stf local --bind-dev-pub tcp://$1:7114 --bind-dev-pull tcp://$1:7116 --public-ip $1 --allow-remote

--- a/Setup/runDB.sh
+++ b/Setup/runDB.sh
@@ -1,0 +1,6 @@
+# 
+# Copyright 2020 VMware, Inc
+# SPDX-License-Identifier:Apache2.0
+# 
+
+rethinkdb &

--- a/stf.sh
+++ b/stf.sh
@@ -1,0 +1,220 @@
+#!/bin/bash
+
+# 
+# Copyright 2020 VMware, Inc
+# SPDX-License-Identifier:Apache2.0
+# 
+
+
+# Bash Menu Script Example
+Black='\033[0;30m'        # Black
+Red='\033[0;31m'          # Red
+Green='\033[0;32m'        # Green
+Yellow='\033[0;33m'       # Yellow
+Blue='\033[0;34m'         # Blue
+Purple='\033[0;35m'       # Purple
+Cyan='\033[0;36m'         # Cyan
+White='\033[0;37m'        # White
+# Bold
+BBlack='\033[1;30m'       # Black
+BRed='\033[1;31m'         # Red
+BGreen='\033[1;32m'       # Green
+BYellow='\033[1;33m'      # Yellow
+BBlue='\033[1;34m'        # Blue
+BPurple='\033[1;35m'      # Purple
+BCyan='\033[1;36m'        # Cyan
+BWhite='\033[1;37m'       # White
+
+# Underline
+UBlack='\033[4;30m'       # Black
+URed='\033[4;31m'         # Red
+UGreen='\033[4;32m'       # Green
+UYellow='\033[4;33m'      # Yellow
+UBlue='\033[4;34m'        # Blue
+UPurple='\033[4;35m'      # Purple
+UCyan='\033[4;36m'        # Cyan
+UWhite='\033[4;37m'       # White
+
+# Background
+On_Black='\033[40m'       # Black
+On_Red='\033[41m'         # Red
+On_Green='\033[42m'       # Green
+On_Yellow='\033[43m'      # Yellow
+On_Blue='\033[44m'        # Blue
+On_Purple='\033[45m'      # Purple
+On_Cyan='\033[46m'        # Cyan
+On_White='\033[47m'       # White
+
+# High Intensity
+IBlack='\033[0;90m'       # Black
+IRed='\033[0;91m'         # Red
+IGreen='\033[0;92m'       # Green
+IYellow='\033[0;93m'      # Yellow
+IBlue='\033[0;94m'        # Blue
+IPurple='\033[0;95m'      # Purple
+ICyan='\033[0;96m'        # Cyan
+IWhite='\033[0;97m'       # White
+
+# Bold High Intensity
+BIBlack='\033[1;90m'      # Black
+BIRed='\033[1;91m'        # Red
+BIGreen='\033[1;92m'      # Green
+BIYellow='\033[1;93m'     # Yellow
+BIBlue='\033[1;94m'       # Blue
+BIPurple='\033[1;95m'     # Purple
+BICyan='\033[1;96m'       # Cyan
+BIWhite='\033[1;97m'      # White
+
+# High Intensity backgrounds
+On_IBlack='\033[0;100m'   # Black
+On_IRed='\033[0;101m'     # Red
+On_IGreen='\033[0;102m'   # Green
+On_IYellow='\033[0;103m'  # Yellow
+On_IBlue='\033[0;104m'    # Blue
+On_IPurple='\033[0;105m'  # Purple
+On_ICyan='\033[0;106m'    # Cyan
+On_IWhite='\033[0;107m'   # White
+echo ""
+echo -e "Welcome to ${BYellow} STF ${White}"
+# echo ""
+# echo -e "This script can ${BWhite}Install${White} & ${BWhite}Run${White} ADF for both ${Cyan} Mac ${White} & ${Cyan} Ubuntu ${White} OS"
+echo ""
+echo -e "${Cyan}For Provider Unit:${White}"
+echo "1) Install Basic STF Setup          [-Role -Command] "
+echo "2) Run Provider                     [-Role -Command -IP]"
+echo ""
+echo -e "${Cyan}For Master Server:${White}"
+echo "1) Install Basic STF Setup          [-Role -Command]"
+echo "2) Link Master Setup                [-Role -Command]"
+echo "3) Run DataBase                     [-Role -Command]"
+echo "4) Run STF Master                   [-Role -Command -IP]"
+echo ""
+echo ""
+echo -e "${Yellow}Options${White}"
+# echo -e " -OS        [ ${BWhite}mac${White} , ${BWhite}ubuntu${White} ]        ${Cyan}Required${White}"
+echo -e " -Role      [ ${BWhite}Provider${White} , ${BWhite}Master${White} ]   ${Cyan}Required${White}"
+echo -e " -Command   [ ${BWhite}1${White} , ${BWhite}2${White} , ${BWhite}3${White} , ${BWhite}4${White} ]       ${Cyan}Required${White}"
+echo -e " -IP        [ ${BWhite}MasterIp${White} ]     "
+echo ""
+echo ""
+echo -e "${Yellow}For Example${White}"
+echo -e " Installing Master Setup :      [ ${BWhite} ./stf.sh -Role Master -Command 1 ${White} ]"
+echo -e " Running Provider Setup  :      [ ${BWhite} ./stf.sh -Role Provider -Command 2 -IP 10.XX.XX.XX ${White} ]"
+echo ""
+echo ""
+
+arg_os="os"
+
+# store arguments in a special array 
+args=("$@") 
+# get number of elements 
+ELEMENTS=${#args[@]} 
+
+
+# for loop 
+for (( i=0;i<$ELEMENTS;i+=2)); do 
+    # echo ${args[${i}]}
+
+    if [ ${args[${i}]} == "-Role" ]; then
+        Role="${args[${i}+1]}"
+    elif [ ${args[${i}]} == "-Command" ]; then
+        Command="${args[${i}+1]}"
+    elif [ ${args[${i}]} == "-IP" ]; then
+        IP="${args[${i}+1]}"
+    fi
+done
+
+if [ -z "$Role" ]; then
+    echo -e "Missing or Inappropriate required Argument ${Red} -Role ${White}"
+    exit 1
+elif [ $Role == "Master" ]; then
+    temp="temp"
+elif [ $Role == "Provider" ]; then
+    temp="temp"
+else
+    echo -e "Inappropriate required Argument ${Red} -Role ${White}"
+    exit 1
+fi
+
+if [ -z "$Command" ]; then
+    echo -e "Missing or Inappropriate required Argument ${Red} -Command ${White}"
+    exit 1
+elif [ $Command == "1" ]; then
+    temp="temp"
+elif [ $Command == "2" ]; then
+    temp="temp"
+elif [ $Command == "3" ]; then
+    temp="temp"
+    if [ $Role == "Provider" ]; then
+        echo -e "Missing or Inappropriate required Argument ${Red} -Command ${White}"
+        exit 1
+    fi
+elif [ $Command == "4" ]; then
+    temp="temp"
+    if [ $Role == "Provider" ]; then
+        echo -e "Missing or Inappropriate required Argument ${Red} -Command ${White}"
+        exit 1
+    fi
+else
+    echo -e "Missing or Inappropriate required Argument ${Red} -Command ${White}"
+    exit 1
+fi
+
+
+if [ $Role == "Provider" ] && [ $Command == "2" ] && [ -z "$IP" ]; then
+    echo -e "Missing Argument ${Red} -IP ${White}"
+    exit 1
+elif [ $Role == "Master" ] && [ $Command == "4" ] && [ -z "$IP" ]; then
+    echo -e "Missing Argument ${Red} -IP ${White}"
+    exit 1
+fi
+
+
+# IP="127.0.0.1" # Default IP
+
+
+if [ "$(uname)" == "Darwin" ]; then
+    # echo "This is Mac"
+    os="mac"
+
+    if [ $Command == "1" ]; then
+        ./Setup/Mac/Install.sh
+        exit 0
+    elif [ $Command == "2" ] && [ $Role == "Master" ]; then
+        ./Setup/Mac/Master.sh
+        exit 0
+    elif [ $Command == "2" ] && [ $Role == "Provider" ]; then
+        ./Setup/Mac/Provider.sh $IP
+        exit 0
+    elif [ $Command == "3" ]; then
+        ./Setup/runDB.sh
+        exit 0
+    elif [ $Command == "4" ] && [ $Role == "Master" ]; then
+        # osascript -e 'tell application "Terminal" to do script "./Setup/Mac/runDB.sh"'
+        ./Setup/Mac/Run.sh $IP
+        exit 0
+    fi
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    # echo "This is Linux"
+    os="ubuntu"
+
+    if [ $Command == "1" ]; then
+        ./Setup/Ubuntu/Install.sh
+        exit 0
+    elif [ $Command == "2" ] && [ $Role == "Master" ]; then
+        ./Setup/Ubuntu/Master.sh
+        exit 0
+    elif [ $Command == "2" ] && [ $Role == "Provider" ]; then
+        ./Setup/Ubuntu/Provider.sh $IP
+        exit 0
+    elif [ $Command == "3" ]; then
+        ./Setup/runDB.sh
+        exit 0
+    elif [ $Command == "4" ] && [ $Role == "Master" ]; then
+        ./Setup/Ubuntu/Run.sh $IP
+        exit 0
+    fi
+else
+    echo -e "${Red} STF Doesn't Support any other OS than Mac & Linux ${White}"
+    exit 0
+fi


### PR DESCRIPTION
Easy installation of STF, with this PR for both Mac & Linux.

now by running `./stf.sh` there will be multiple options one can proceed with.

<img width="992" alt="Screenshot 2020-06-18 at 9 16 29 AM" src="https://user-images.githubusercontent.com/65212216/84976102-aad1f380-b144-11ea-9970-2697a8254042.png">
